### PR TITLE
fix iteration increments

### DIFF
--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -137,8 +137,8 @@ class OnPolicyRunner:
             if it % self.save_interval == 0:
                 self.save(os.path.join(self.log_dir, 'model_{}.pt'.format(it)))
             ep_infos.clear()
-        
-        self.current_learning_iteration += num_learning_iterations
+            self.current_learning_iteration += 1
+
         self.save(os.path.join(self.log_dir, 'model_{}.pt'.format(self.current_learning_iteration)))
 
     def log(self, locs, width=80, pad=35):
@@ -176,7 +176,7 @@ class OnPolicyRunner:
             self.writer.add_scalar('Train/mean_reward/time', statistics.mean(locs['rewbuffer']), self.tot_time)
             self.writer.add_scalar('Train/mean_episode_length/time', statistics.mean(locs['lenbuffer']), self.tot_time)
 
-        str = f" \033[1m Learning iteration {locs['it']}/{self.current_learning_iteration + locs['num_learning_iterations']} \033[0m "
+        str = f" \033[1m Learning iteration {locs['it']}/{locs['tot_iter']} \033[0m "
 
         if len(locs['rewbuffer']) > 0:
             log_string = (f"""{'#' * width}\n"""

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='rsl_rl',
       description='Fast and simple RL algorithms implemented in pytorch',
       python_requires='>=3.6',
       install_requires=[
+            "setuptools==59.5.0",
             "torch>=1.4.0",
             "torchvision>=0.5.0",
             "numpy>=1.16.4"


### PR DESCRIPTION
In on_policy_learning.py, `current_learning_iteration` is only being incremented at the end of the learning run, so all intermediate saves have the incorrect iteration. This is fixed, so if you resume with an intermediate checkpoint, it starts counting from the correct place (mainly just a nice-to-have for the tensorboard visualizations).