### PR TITLE
Fix mask for RNN hidden states reset

### DIFF
--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -30,6 +30,7 @@ class PPO:
         schedule="fixed",
         desired_kl=0.01,
         device="cpu",
+        **kwargs,
     ):
         self.device = device
 

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -30,7 +30,6 @@ class PPO:
         schedule="fixed",
         desired_kl=0.01,
         device="cpu",
-        **kwargs,
     ):
         self.device = device
 

--- a/rsl_rl/modules/actor_critic_recurrent.py
+++ b/rsl_rl/modules/actor_critic_recurrent.py
@@ -92,6 +92,8 @@ class Memory(torch.nn.Module):
         return out
 
     def reset(self, dones=None):
+        if dones is not None:
+            dones = dones.bool()
         # When the RNN is an LSTM, self.hidden_states_a is a list with hidden_state and cell_state
         for hidden_state in self.hidden_states:
             hidden_state[..., dones, :] = 0.0


### PR DESCRIPTION
This PR updates the reset function to convert the `dones` mask to a boolean mask before applying it to reset hidden states. Previously, the function used a 0/1 mask directly, which selected the first and second set of indices in the last but one dimension, rather than resetting the hidden states at the desired positions indicated by 1 in the mask. By converting the `dones` mask to a boolean mask, we ensure that the hidden states are correctly reset at the specified positions.