### PR TITLE
Accounts for start_iter when computing ETA

### DIFF
--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -245,8 +245,8 @@ class OnPolicyRunner:
             f"""{'Total timesteps:':>{pad}} {self.tot_timesteps}\n"""
             f"""{'Iteration time:':>{pad}} {iteration_time:.2f}s\n"""
             f"""{'Total time:':>{pad}} {self.tot_time:.2f}s\n"""
-            f"""{'ETA:':>{pad}} {self.tot_time / (locs['it'] + 1) * (
-                               locs['num_learning_iterations'] - locs['it']):.1f}s\n"""
+            f"""{'ETA:':>{pad}} {self.tot_time / (locs['it'] - locs['start_iter'] + 1) * (
+                               locs['start_iter'] + locs['num_learning_iterations'] - locs['it']):.1f}s\n"""
         )
         print(log_string)
 


### PR DESCRIPTION
The previous ETA calculation gave negative results when using `--resume` from Isaac Lab's RL examples. This change fixes that. It should probably be tested in other use cases to make sure it still works!

Fixes: https://github.com/leggedrobotics/rsl_rl/issues/10