### PR TITLE
disable empirical normalizer updates on resume training

### DIFF
--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -42,8 +42,12 @@ class OnPolicyRunner:
         self.save_interval = self.cfg["save_interval"]
         self.empirical_normalization = self.cfg["empirical_normalization"]
         if self.empirical_normalization:
-            self.obs_normalizer = EmpiricalNormalization(shape=[num_obs], until=1.0e8).to(self.device)
-            self.critic_obs_normalizer = EmpiricalNormalization(shape=[num_critic_obs], until=1.0e8).to(self.device)
+            if train_cfg.get("resume") == True:
+                until = 0
+            else:
+                until = 1.0e8
+            self.obs_normalizer = EmpiricalNormalization(shape=[num_obs], until=until).to(self.device)
+            self.critic_obs_normalizer = EmpiricalNormalization(shape=[num_critic_obs], until=until).to(self.device)
         else:
             self.obs_normalizer = torch.nn.Identity()  # no normalization
             self.critic_obs_normalizer = torch.nn.Identity()  # no normalization


### PR DESCRIPTION
This completely disables the updates if "resume" is in the agent_cfg and True. 

Should we check how many iterations/updates were done previously and only disable if over a threshold? 