### PR TITLE
Fixes error caused by non UTF-8 characters in git diff

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,3 +29,4 @@ Please keep the lists sorted alphabetically.
 * Matthijs van der Boon
 * Mayank Mittal
 * Zhang Chong
+* Ziqi Fan

--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -78,7 +78,7 @@ def store_code_state(logdir, repositories) -> list:
             continue
         # write the diff file
         print(f"Storing git diff for '{repo_name}' in: {diff_file_name}")
-        with open(diff_file_name, "x") as f:
+        with open(diff_file_name, "x", encoding="utf-8") as f:
             content = f"--- git status ---\n{repo.git.status()} \n\n\n--- git diff ---\n{repo.git.diff(t)}"
             f.write(content)
         # add the file path to the list of files to be uploaded


### PR DESCRIPTION
When there are non-UTF-8 characters in git diff, the following error will be reported:

```
Traceback (most recent call last):
  File "/home/ubuntu/workspaces/IsaacLab/source/standalone/workflows/rsl_rl/train.py", line 135, in <module>
    main()
  File "/home/ubuntu/workspaces/IsaacLab/source/standalone/workflows/rsl_rl/train.py", line 127, in main
    runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/rsl_rl/runners/on_policy_runner.py", line 160, in learn
    git_file_paths = store_code_state(self.log_dir, self.git_status_repos)
  File "/home/ubuntu/anaconda3/envs/isaaclab/lib/python3.10/site-packages/rsl_rl/utils/utils.py", line 85, in store_code_state
    f.write(content)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1007-1025: ordinal not in range(128)
```

So need to add `encoding="utf-8"`