### PR TITLE
Fix bug in ActorCriticRecurrent hidden state reset

### DIFF
--- a/rsl_rl/modules/actor_critic_recurrent.py
+++ b/rsl_rl/modules/actor_critic_recurrent.py
@@ -93,5 +93,7 @@ class Memory(torch.nn.Module):
 
     def reset(self, dones=None):
         # When the RNN is an LSTM, self.hidden_states_a is a list with hidden_state and cell_state
+        if self.hidden_states is None:
+            return
         for hidden_state in self.hidden_states:
-            hidden_state[..., dones, :] = 0.0
+            hidden_state[..., dones.nonzero(), :] = 0.0


### PR DESCRIPTION
This PR is basically same as https://github.com/leggedrobotics/rsl_rl/pull/35
Since dones tensor is torch.long, you cannot use it as index, but should convert it to bool or dones.nonzero() 