### PR TITLE
Adds support for pip packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # builds
 *.egg-info
+build/*
+dist/*
 
 # cache
 __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,36 @@ reportMissingModuleSource = "none" # -> most common: prettytable in mdp managers
 reportGeneralTypeIssues = "none"       # -> raises 218 errors (usage of literal MISSING in dataclasses)
 reportOptionalMemberAccess = "warning" # -> raises 8 errors
 reportPrivateUsage = "warning"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rsl_rl_lib"
+version = "2.0.2"
+authors = [
+  { name="Nikita Rudin, David Hoeller", email="rudinn@ethz.ch" },
+]
+description = "Fast and simple RL algorithms implemented in pytorch"
+readme = "README.md"
+requires-python = ">=3.6"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = {text = "BSD-3"}
+dependencies = [
+    "torch>=1.10.0",
+    "torchvision>=0.5.0",
+    "numpy>=1.16.4",
+    "GitPython",
+    "onnx",
+]
+
+[project.urls]
+Homepage = "https://github.com/leggedrobotics/rsl_rl"
+Issues = "https://github.com/leggedrobotics/rsl_rl/issues"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,5 @@ from setuptools import find_packages, setup
 
 setup(
     name="rsl_rl",
-    version="2.0.2",
     packages=find_packages(),
-    author="ETH Zurich, NVIDIA CORPORATION",
-    maintainer="Nikita Rudin, David Hoeller",
-    maintainer_email="rudinn@ethz.ch",
-    url="https://github.com/leggedrobotics/rsl_rl",
-    license="BSD-3",
-    description="Fast and simple RL algorithms implemented in pytorch",
-    python_requires=">=3.6",
-    install_requires=[
-        "torch>=1.10.0",
-        "torchvision>=0.5.0",
-        "numpy>=1.16.4",
-        "GitPython",
-        "onnx",
-    ],
 )


### PR DESCRIPTION
Adds build tools and dependencies to pyproject.toml to allow for pip packaging for the library.

To build package:
pip install --upgrade build
python -m build

To upload package:
pip install --upgrade twine
python -m twine upload dist/*

To upload to test server:
python -m twine upload --repository testpypi dist/*

To install from test server:
pip install --index-url https://test.pypi.org/simple/ --no-deps rsl_rl_lib