### PR TITLE
Fixes mean_entropy by dividing by num_updates

### DIFF
--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -361,6 +361,7 @@ class PPO:
         num_updates = self.num_learning_epochs * self.num_mini_batches
         mean_value_loss /= num_updates
         mean_surrogate_loss /= num_updates
+        mean_entropy /= num_updates
         # -- For RND
         if mean_rnd_loss is not None:
             mean_rnd_loss /= num_updates


### PR DESCRIPTION
This PR resolves a small bug by dividing `mean_entropy` by the number of updates in PPO training as other losses are computed.