### PR TITLE
Fixes gradient propogation through std-dev

### DIFF
--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -101,7 +101,8 @@ class ActorCritic(nn.Module):
 
     def update_distribution(self, observations):
         mean = self.actor(observations)
-        self.distribution = Normal(mean, mean * 0.0 + self.std)
+        std = self.std.expand_as(mean)
+        self.distribution = Normal(mean, std)
 
     def act(self, observations, **kwargs):
         self.update_distribution(observations)


### PR DESCRIPTION
Earlier, we were doing the operation `0.0*mean + self.std`. This sometimes caused gradients to propogate through the mean which would lead to `NaNs` as has been reported internally.

This MR fixes this issue.