### PR TITLE
Adds support for log-std parameter in ActorCritic

### DIFF
--- a/config/dummy_config.yaml
+++ b/config/dummy_config.yaml
@@ -69,6 +69,7 @@ policy:
   actor_hidden_dims: [128, 128, 128]
   critic_hidden_dims: [128, 128, 128]
   init_noise_std: 1.0
+  std_type: "scalar"  # 'scalar' or 'log'
   # only needed for `ActorCriticRecurrent`
   # rnn_type: 'lstm'
   # rnn_hidden_size: 512

--- a/config/dummy_config.yaml
+++ b/config/dummy_config.yaml
@@ -69,7 +69,7 @@ policy:
   actor_hidden_dims: [128, 128, 128]
   critic_hidden_dims: [128, 128, 128]
   init_noise_std: 1.0
-  std_type: "scalar"  # 'scalar' or 'log'
+  noise_std_type: "scalar"  # 'scalar' or 'log'
   # only needed for `ActorCriticRecurrent`
   # rnn_type: 'lstm'
   # rnn_hidden_size: 512

--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -24,7 +24,7 @@ class ActorCritic(nn.Module):
         critic_hidden_dims=[256, 256, 256],
         activation="elu",
         init_noise_std=1.0,
-        std_type: str = "scalar",
+        noise_std_type: str = "scalar",
         **kwargs,
     ):
         if kwargs:
@@ -65,14 +65,14 @@ class ActorCritic(nn.Module):
         print(f"Critic MLP: {self.critic}")
 
         # Action noise
-        self.std_type = std_type
-        if self.std_type == "scalar":
+        self.noise_std_type = noise_std_type
+        if self.noise_std_type == "scalar":
             self.std = nn.Parameter(init_noise_std * torch.ones(num_actions))
-        elif self.std_type == "log":
+        elif self.noise_std_type == "log":
             self.log_std = nn.Parameter(torch.log(init_noise_std * torch.ones(num_actions)))
             self.std = torch.exp(self.log_std)
         else:
-            raise ValueError(f"Unknown std_dev_type: {self.std_type}. Should be 'scalar' or 'log'")
+            raise ValueError(f"Unknown std_dev_type: {self.noise_std_type}. Should be 'scalar' or 'log'")
 
         # Action distribution (populated in update_distribution)
         self.distribution = None

--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -72,7 +72,7 @@ class ActorCritic(nn.Module):
             self.log_std = nn.Parameter(torch.log(init_noise_std * torch.ones(num_actions)))
             self.std = torch.exp(self.log_std)
         else:
-            raise ValueError(f"Unknown std_dev_type: {self.noise_std_type}. Should be 'scalar' or 'log'")
+            raise ValueError(f"Unknown standard deviation type: {self.noise_std_type}. Should be 'scalar' or 'log'")
 
         # Action distribution (populated in update_distribution)
         self.distribution = None

--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -101,7 +101,8 @@ class ActorCritic(nn.Module):
 
     def update_distribution(self, observations):
         mean = self.actor(observations)
-        self.distribution = Normal(mean, mean * 0.0 + self.std)
+        std = self.std.expand_as(mean)
+        self.distribution = Normal(mean, std)
 
     def act(self, observations, **kwargs):
         self.update_distribution(observations)

--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -261,7 +261,7 @@ class OnPolicyRunner:
                 else:
                     self.writer.add_scalar("Episode/" + key, value, locs["it"])
                     ep_string += f"""{f'Mean episode {key}:':>{pad}} {value:.4f}\n"""
-        mean_std = self.alg.actor_critic.std.mean()
+        mean_std = self.alg.actor_critic.action_std.mean()
         fps = int(self.num_steps_per_env * self.env.num_envs / (locs["collection_time"] + locs["learn_time"]))
 
         # -- Losses


### PR DESCRIPTION
Since doing logstd is sometimes more stable than scalar std (as the former makes sure the value is always positive), this MR adds an option to switch to `log_std` inside the ActorCritic.

Users can switch between different std types through the parameter: `noise_std_type`. This also allows them to add more types in the future.

Reference: 
* https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/
* https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py#L136-L137
