### PR TITLE
Corrects disabling of arguments when creating Normal distribution

### DIFF
--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -67,7 +67,7 @@ class ActorCritic(nn.Module):
         self.std = nn.Parameter(init_noise_std * torch.ones(num_actions))
         self.distribution = None
         # disable args validation for speedup
-        Normal.set_default_validate_args = False
+        Normal.set_default_validate_args(False)
 
         # seems that we get better performance without init
         # self.init_memory_weights(self.memory_a, 0.001, 0.)


### PR DESCRIPTION
Previously in `actor_critic.py`: https://github.com/leggedrobotics/rsl_rl/blob/main/rsl_rl/modules/actor_critic.py#L69-L70

```python
# disable args validation for speedup
Normal.set_default_validate_args = False
```

Now:

```python
# disable args validation for speedup
Normal.set_default_validate_args(False)
```

Reason: Likely version upgrade of torch to 2.0.
Reference: https://pytorch.org/docs/stable/distributions.html#torch.distributions.distribution.Distribution.set_default_validate_args