### PR TITLE
Fix padding shape in split_and_pad_trajectories to support arbitrary additional dimensions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ Please keep the lists sorted alphabetically.
 
 ## Contributors
 
+* Bikram Pandit
 * Eric Vollenweider
 * Fabian Jenelten
 * Lorenzo Terenzi

--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -63,7 +63,7 @@ def split_and_pad_trajectories(tensor, dones):
     # Extract the individual trajectories
     trajectories = torch.split(tensor.transpose(1, 0).flatten(0, 1), trajectory_lengths_list)
     # add at least one full length trajectory
-    trajectories = trajectories + (torch.zeros(tensor.shape[0], tensor.shape[-1], device=tensor.device),)
+    trajectories = trajectories + (torch.zeros(tensor.shape[0], *tensor.shape[2:], device=tensor.device),)
     # pad the trajectories to the length of the longest trajectory
     padded_trajectories = torch.nn.utils.rnn.pad_sequence(trajectories)
     # remove the added tensor


### PR DESCRIPTION
### Description
This PR fixes an issue in `split_and_pad_trajectories(tensor, dones)` where creating a full-length trajectory incorrectly assumes the input tensor is 3D (`[time, number of envs, feature_dim]`). This assumption fails for higher-dimensional tensors, such as images (`[time, number of envs, channel, width, height]`), where there are multiple additional dimensions. The previous approach, which used only the last dimension (`shape[-1]`), caused shape mismatches when adding a full-length zero trajectory.

### Key Changes
Instead of assuming a single feature dimension (`shape[-1]`), the full-length trajectory is now created using all feature dimensions beyond the second dimension (`number of environments`), represented by `*shape[2:]`.
This ensures compatibility with tensors of arbitrary additional dimensions while preserving the intended functionality.

#### For reference, the following line is changed:
https://github.com/leggedrobotics/rsl_rl/blob/f80d4750fbdfb62cfdb0c362b7063450f427cf35/rsl_rl/utils/utils.py#L66