### PR TITLE
Disable distribution mean gradient propagation into action noise std for StudentTeacher

### DIFF
--- a/rsl_rl/modules/student_teacher.py
+++ b/rsl_rl/modules/student_teacher.py
@@ -92,7 +92,8 @@ class StudentTeacher(nn.Module):
 
     def update_distribution(self, observations):
         mean = self.student(observations)
-        self.distribution = Normal(mean, mean * 0.0 + self.std)
+        std = self.std.expand_as(mean)
+        self.distribution = Normal(mean, std)
 
     def act(self, observations):
         self.update_distribution(observations)


### PR DESCRIPTION
This pull request includes changes to stop gradient computation for the noise std, in the same fashion of https://github.com/leggedrobotics/rsl_rl/pull/66, as it may produce NaNs during the training.

Changes to handling action noise standard deviation parameters:

Improvements to distribution updates:

* [`rsl_rl/modules/student_teacher.py`](diffhunk://#diff-6ae34b9682253107368d98655dfe676225eddff84c2c99966ef24bdf6da08debL95-R96): Updated the `update_distribution` method to expand the `std` parameter to match the shape of `mean` before creating the `Normal` distribution.