### PR TITLE
Fixes git repository code storage function

### DIFF
--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -90,13 +90,13 @@ def store_code_state(logdir, repositories) -> list:
     for repository_file_path in repositories:
         try:
             repo = git.Repo(repository_file_path, search_parent_directories=True)
+            t = repo.head.commit.tree
         except Exception:
             print(f"Could not find git repository in {repository_file_path}. Skipping.")
             # skip if not a git repository
             continue
         # get the name of the repository
         repo_name = pathlib.Path(repo.working_dir).name
-        t = repo.head.commit.tree
         diff_file_name = os.path.join(git_log_dir, f"{repo_name}.diff")
         # check if the diff file already exists
         if os.path.isfile(diff_file_name):


### PR DESCRIPTION
Fixes the following issue observed when running on cluster:

```
  File "C:\ProgramData\miniconda3\envs\cenv_isaaclab_c12\lib\site-packages\git\refs\symbolic.py", line 257, in _get_ref_info_helper
    raise ValueError("Reference at %r does not exist" % ref_path)
ValueError: Reference at 'refs/heads/master' does not exist
```