### PR TITLE
Upload video to wandb

### DIFF
--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -350,6 +350,10 @@ class OnPolicyRunner:
 
         str = f" \033[1m Learning iteration {locs['it']}/{locs['tot_iter']} \033[0m "
 
+        # Upload video to wandb
+        if self.logger_type == "wandb" and not self.disable_logs:
+            self.writer.add_video_files(self.log_dir, fps=self.cfg["video_fps"], step=locs["it"])
+            
         if len(locs["rewbuffer"]) > 0:
             log_string = (
                 f"""{'#' * width}\n"""

--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -352,7 +352,12 @@ class OnPolicyRunner:
 
         # Upload video to wandb
         if self.logger_type == "wandb" and not self.disable_logs:
-            self.writer.add_video_files(self.log_dir, fps=self.cfg["video_fps"], step=locs["it"])
+            # use video_fps from cfg if available or default to 30
+            if "video_fps" in self.cfg:
+                video_fps = self.cfg["video_fps"]
+            else:
+                video_fps = 30
+            self.writer.add_video_files(self.log_dir, fps=video_fps, step=locs["it"])
             
         if len(locs["rewbuffer"]) > 0:
             log_string = (

--- a/rsl_rl/utils/wandb_utils.py
+++ b/rsl_rl/utils/wandb_utils.py
@@ -79,7 +79,7 @@ class WandbSummaryWriter(SummaryWriter):
 
     def add_video_files(self, log_dir: str, step: int, fps: int = 30):
         # Check if there are video files in the video directory
-        videos_dir = os.path.join(log_dir, "videos")
+        videos_dir = os.path.join(log_dir, "videos", "train")
         if os.path.exists(videos_dir):
             # append the new video files to the existing list
             for video_file in os.listdir(videos_dir):


### PR DESCRIPTION
Uploads videos in the log directory to wandb.

Added a method to `WandbSummaryWriter` to check for .mp4 in log directory and upload them to wandb. This method is triggered inside the `log` method of runner. 

I understand there is another PR in works addressing this, I was working on this for a project anyway.

Please share your feedback, thank you for your time.