### PR TITLE
Fixes logging issue by replacing `.pop` with `.get` for `class_name` in config

### DIFF
--- a/rsl_rl/algorithms/distillation.py
+++ b/rsl_rl/algorithms/distillation.py
@@ -30,6 +30,8 @@ class Distillation:
         device="cpu",
         # Distributed training parameters
         multi_gpu_cfg: dict | None = None,
+        # Unused parameter
+        class_name: str = "Distillation",
     ):
         # device-related parameters
         self.device = device

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -45,6 +45,8 @@ class PPO:
         symmetry_cfg: dict | None = None,
         # Distributed training parameters
         multi_gpu_cfg: dict | None = None,
+        # Unused parameter
+        class_name: str = "PPO",
     ):
         # device-related parameters
         self.device = device

--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -68,7 +68,7 @@ class OnPolicyRunner:
             num_privileged_obs = num_obs
 
         # evaluate the policy class
-        policy_class = eval(self.policy_cfg.pop("class_name"))
+        policy_class = eval(self.policy_cfg.get("class_name"))
         policy: ActorCritic | ActorCriticRecurrent | StudentTeacher | StudentTeacherRecurrent = policy_class(
             num_obs, num_privileged_obs, self.env.num_actions, **self.policy_cfg
         ).to(self.device)
@@ -92,7 +92,7 @@ class OnPolicyRunner:
             self.alg_cfg["symmetry_cfg"]["_env"] = env
 
         # initialize algorithm
-        alg_class = eval(self.alg_cfg.pop("class_name"))
+        alg_class = eval(self.alg_cfg.get("class_name"))
         self.alg: PPO | Distillation = alg_class(
             policy, device=self.device, **self.alg_cfg, multi_gpu_cfg=self.multi_gpu_cfg
         )


### PR DESCRIPTION
## Description

Previously, the configuration code used `.pop("class_name")` to retrieve the `class_name` field before constructing the algorithm or policy. While this works when `class_name` is only needed at construction time, it causes the `class_name` entry to be **removed** from the config dictionary (`cfg`) before it can be logged.

This leads to a problem: when using logging tools like **WandB's Run Comparator** or similar config-diff utilities, runs using different `class_name` values (e.g., different algorithms or policies) appear **identical** because `class_name` is missing from the logged configuration. I encountered this issue while comparing runs: even though I used different `class_name`, their configs looked the same in the UI, leading to confusion.

To fix this, I replaced `.pop("class_name")` with `.get("class_name")`, so that the `class_name` remains in the config and is available for proper logging.

Because the `class_name` field would now be present as an extra key in `kwargs` when constructing the algorithm or policy classes, we need to ensure constructors can tolerate this. This is already handled for `ActorCritic` by accepting `**kwargs`, and for `PPO` I made a similar adjustment.

This approach preserves clean logging **without breaking** how policies or algorithms are initialized.
