### PR TITLE
Fixes unexpected keyword argument `learning_rate` within `RandomNetworkDistillation`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Please keep the lists sorted alphabetically.
 * Lorenzo Terenzi
 * Marko Bjelonic
 * Matthijs van der Boon
+* Özhan Özen
 * Pascal Roth
 * Zhang Chong
 * Ziqi Fan

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -59,12 +59,13 @@ class PPO:
 
         # RND components
         if rnd_cfg is not None:
+            # Extract learning rate and remove it from the original dict
+            learning_rate = rnd_cfg.pop("learning_rate", 1e-3)
             # Create RND module
-            rnd_cfg_ = {k: v for k, v in rnd_cfg.items() if k != "learning_rate"}  # remove lr key for the RND class
-            self.rnd = RandomNetworkDistillation(device=self.device, **rnd_cfg_)
+            self.rnd = RandomNetworkDistillation(device=self.device, **rnd_cfg)
             # Create RND optimizer
             params = self.rnd.predictor.parameters()
-            self.rnd_optimizer = optim.Adam(params, lr=rnd_cfg.get("learning_rate", 1e-3))
+            self.rnd_optimizer = optim.Adam(params, lr=learning_rate)
         else:
             self.rnd = None
             self.rnd_optimizer = None

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -60,7 +60,8 @@ class PPO:
         # RND components
         if rnd_cfg is not None:
             # Create RND module
-            self.rnd = RandomNetworkDistillation(device=self.device, **rnd_cfg)
+            rnd_cfg_ = {k: v for k, v in rnd_cfg.items() if k != "learning_rate"}  # remove lr key for the RND class
+            self.rnd = RandomNetworkDistillation(device=self.device, **rnd_cfg_)
             # Create RND optimizer
             params = self.rnd.predictor.parameters()
             self.rnd_optimizer = optim.Adam(params, lr=rnd_cfg.get("learning_rate", 1e-3))


### PR DESCRIPTION
During the construction of `RandomNetworkDistillation` within the `PPO` class:

https://github.com/leggedrobotics/rsl_rl/blob/d38a378b13a60ea570923754184f84f48979ad74/rsl_rl/algorithms/ppo.py#L60-L66

the `rnd_cfg` dictionary argument contains the key `learning_rate`, which is unexpected for `RandomNetworkDistillation`, creating issues.

The PR fixes this by ~~removing `learning_rate` from a shallow copy of the dictionary~~, popping out the `learning_rate` from the `rnd_cfg` dictionary, which is provided to the `RandomNetworkDistillation` constructor.