### PR TITLE
Add reshuffle_each_epoch argument to control mini-batch shuffling per…

### DIFF
--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -39,6 +39,7 @@ class PPO:
         desired_kl=0.01,
         device="cpu",
         normalize_advantage_per_mini_batch=False,
+        reshuffle_each_epoch=False,
         # RND parameters
         rnd_cfg: dict | None = None,
         # Symmetry parameters
@@ -114,6 +115,7 @@ class PPO:
         self.schedule = schedule
         self.learning_rate = learning_rate
         self.normalize_advantage_per_mini_batch = normalize_advantage_per_mini_batch
+        self.reshuffle_each_epoch = reshuffle_each_epoch
 
     def init_storage(
         self, training_type, num_envs, num_transitions_per_env, actor_obs_shape, critic_obs_shape, actions_shape
@@ -204,7 +206,9 @@ class PPO:
         if self.policy.is_recurrent:
             generator = self.storage.recurrent_mini_batch_generator(self.num_mini_batches, self.num_learning_epochs)
         else:
-            generator = self.storage.mini_batch_generator(self.num_mini_batches, self.num_learning_epochs)
+            generator = self.storage.mini_batch_generator(
+                self.num_mini_batches, self.num_learning_epochs, self.reshuffle_each_epoch
+            )
 
         # iterate over batches
         for (

--- a/rsl_rl/storage/rollout_storage.py
+++ b/rsl_rl/storage/rollout_storage.py
@@ -181,7 +181,7 @@ class RolloutStorage:
             ], self.dones[i]
 
     # for reinforcement learning with feedforward networks
-    def mini_batch_generator(self, num_mini_batches, num_epochs=8):
+    def mini_batch_generator(self, num_mini_batches, num_epochs=8, reshuffle_each_epoch: bool = False):
         if self.training_type != "rl":
             raise ValueError("This function is only available for reinforcement learning training.")
         batch_size = self.num_envs * self.num_transitions_per_env
@@ -210,6 +210,9 @@ class RolloutStorage:
             rnd_state = self.rnd_state.flatten(0, 1)
 
         for epoch in range(num_epochs):
+            if reshuffle_each_epoch and epoch > 0:
+                indices = torch.randperm(num_mini_batches * mini_batch_size, requires_grad=False, device=self.device)
+
             for i in range(num_mini_batches):
                 # Select the indices for the mini-batch
                 start = i * mini_batch_size


### PR DESCRIPTION
### Summary

This PR improves the mini-batch generator in the reinforcement learning training pipeline by introducing the `reshuffle_each_epoch` parameter. This parameter controls whether data indices are reshuffled at each epoch or kept fixed.

### Motivation

In reinforcement learning, especially in PPO-style policy optimization, shuffling the training data indices at each epoch can improve generalization and reduce correlation between samples. However, some use cases require fixed mini-batch ordering across epochs to enable reproducible experiments and debugging. This PR introduces an explicit toggle to support both workflows.

### Details

- The `reshuffle_each_epoch` flag defaults to `False` to maintain deterministic iteration over mini-batches across epochs.  
- When `reshuffle_each_epoch=True`, mini-batch indices are reshuffled at the start of every epoch, enabling new mini-batch orders per epoch and improved generalization.

### References

The `reshuffle_each_epoch` argument implemented here serves a role analogous to the `shuffle` parameter in PyTorch's [`torch.utils.data.DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader). Setting `shuffle=True` causes the data sampler to reshuffle dataset indices at the start of each epoch, which helps reduce model overfitting and improves generalization.

Similarly, this PR's `reshuffle_each_epoch` flag controls whether mini-batch indices are reshuffled every epoch (`True`), or fixed after the initial shuffle (`False`), providing flexibility in how training data is fed during reinforcement learning updates.

### Testing

- Verified that `reshuffle_each_epoch=True` produces new mini-batch orders per epoch.  
- Verified that `reshuffle_each_epoch=False` preserves mini-batch order across epochs.  
- All existing unit tests and pre-commit hooks pass successfully.

Please review and advise if further adjustments are necessary.
