### PR TITLE
Feat/runname display

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,5 +35,6 @@ Please keep the lists sorted alphabetically.
 * Matthijs van der Boon
 * Özhan Özen
 * Pascal Roth
+* Shaoshu Su
 * Zhang Chong
 * Ziqi Fan

--- a/rsl_rl/runners/on_policy_runner.py
+++ b/rsl_rl/runners/on_policy_runner.py
@@ -239,10 +239,14 @@ class OnPolicyRunner:
 
         str = f" \033[1m Learning iteration {locs['it']}/{locs['tot_iter']} \033[0m "
 
+        run_name = self.cfg.get("run_name")
+        run_name_string = f"""{'Run name:':>{pad}} {run_name}\n""" if run_name else ""
+
         if len(locs["rewbuffer"]) > 0:
             log_string = (
                 f"""{'#' * width}\n"""
                 f"""{str.center(width, ' ')}\n\n"""
+                f"""{run_name_string}"""
                 f"""{'Computation:':>{pad}} {fps:.0f} steps/s (collection: {locs[
                     'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
                 f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""
@@ -263,6 +267,7 @@ class OnPolicyRunner:
             log_string = (
                 f"""{'#' * width}\n"""
                 f"""{str.center(width, ' ')}\n\n"""
+                f"""{run_name_string}"""
                 f"""{'Computation:':>{pad}} {fps:.0f} steps/s (collection: {locs[
                     'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
                 f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""


### PR DESCRIPTION
## Description

Previously, during training, the `on_policy_runner` logging output did not display the current run name, making it harder to distinguish logs between different training sessions when multiple runs were launched in succession or in parallel.

To improve the training log clarity and traceability, I added support to display the configured `run_name` in the logging output of `rsl_rl/runners/on_policy_runner.py`. 

If the `run_name` field is specified in the configuration—such as in the [Isaac Lab training example](https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/rl_existing_scripts.html):

```bash
./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
    --task Isaac-Cartpole-v0 --run_name cartpole_rsl_rl
```
—the run name will now appear in each log update under the label **"Run name:"**:
```
################################################################################
                        Learning iteration 5/150                        

                          Run name: cartpole_rsl_rl
                       Computation: 90014 steps/s (collection: 0.668s, learning 0.060s)
             Mean action noise std: 0.96
          Mean value_function loss: 0.2114
               Mean surrogate loss: -0.0055
                 Mean entropy loss: 1.3755
                       Mean reward: -3.72
               Mean episode length: 91.66
              Episode_Reward/alive: 0.2862
        Episode_Reward/terminating: -0.0051
           Episode_Reward/pole_pos: -0.9367
           Episode_Reward/cart_vel: -0.0072
           Episode_Reward/pole_vel: -0.0056
      Episode_Termination/time_out: 11.0000
Episode_Termination/cart_out_of_bounds: 36.1875
--------------------------------------------------------------------------------
                   Total timesteps: 393216
                    Iteration time: 0.73s
                      Time elapsed: 00:00:04
                               ETA: 00:01:55
```

This enhancement helps users quickly identify the corresponding training session, which is especially useful when monitoring multiple or long-running experiments.

This addition is optional and non-intrusive: if `run_name` is not set, the log display remains unchanged.

## What’s Changed

* Display of `run_name` added to training logs in `on_policy_runner.py`.
* `run_name` is conditionally fetched from `self.cfg` and formatted neatly using the same padded alignment style as other log fields.
* Logging behavior remains unchanged if `run_name` is not defined.

## Type of Change

* 🧠 **Enhancement** (non-breaking addition of functionality)

## Checklist
* [x] Ran `pre-commit run --all-files` and all pre-commit checks pass
* [x] Verified that the training output now includes the `run_name` when provided
* [x] Confirmed no unintended side effects or regressions in log formatting
* [x] Maintained backward compatibility (log remains unchanged if `run_name` is not set)
* [x] No new warnings introduced
