### PR TITLE
Fix: make act_inference return policy mean (without std dev) at deployment time

### DIFF
--- a/rsl_rl/modules/actor_critic.py
+++ b/rsl_rl/modules/actor_critic.py
@@ -149,7 +149,7 @@ class ActorCritic(nn.Module):
         obs = self.get_actor_obs(obs)
         obs = self.actor_obs_normalizer(obs)
         if self.state_dependent_std:
-            return self.actor(obs).select(dim=-2, index=0)
+            return self.actor(obs)[..., 0, :]
         else:
             return self.actor(obs)
 

--- a/rsl_rl/modules/actor_critic_recurrent.py
+++ b/rsl_rl/modules/actor_critic_recurrent.py
@@ -168,7 +168,7 @@ class ActorCriticRecurrent(nn.Module):
         obs = self.actor_obs_normalizer(obs)
         out_mem = self.memory_a(obs).squeeze(0)
         if self.state_dependent_std:
-            return self.actor(out_mem).select(dim=-2, index=0)
+            return self.actor(out_mem)[..., 0, :]
         else:
             return self.actor(out_mem)
 


### PR DESCRIPTION
When trained with state-dependent standard-dev, the policy network outputs both the mean and std-dev.

The default for `act_inference` is that it only returns the policy mean. The MR makes that the case when the policy was trained with state-dependent standard-dev.