### PR TITLE
Fix CNNModel._get_obs_dim accessing attribute before assignment

### DIFF
--- a/rsl_rl/models/cnn_model.py
+++ b/rsl_rl/models/cnn_model.py
@@ -140,7 +140,7 @@ class CNNModel(MLPModel):
             else:
                 raise ValueError(f"Invalid observation shape for {obs_group}: {obs[obs_group].shape}")
 
-        assert self.obs_groups_2d, "No 2D observations are provided. If this is intentional, use the MLP model instead."
+        assert obs_groups_2d, "No 2D observations are provided. If this is intentional, use the MLP model instead."
 
         # Store active 2D observation groups and dimensions directly as attributes
         self.obs_dims_2d = obs_dims_2d


### PR DESCRIPTION
## Summary
- `_get_obs_dim` asserts `self.obs_groups_2d` (line 143) but the attribute is only assigned on line 148
- Because `nn.Module.__getattr__` raises `AttributeError` for unknown attributes, this always crashes with an unhelpful error instead of showing the intended assertion message
- Fix: check the local variable `obs_groups_2d` instead of `self.obs_groups_2d`

## Repro
Any use of `CNNModel` with valid 2D observations hits this crash:
```
AttributeError: 'CNNModel' object has no attribute 'obs_groups_2d'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)