### PR TITLE
Fix three bugs: missing raise, wrong RND broadcast index, variable typo

### DIFF
--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -513,7 +513,7 @@ class PPO:
         self.actor.load_state_dict(model_params[0])
         self.critic.load_state_dict(model_params[1])
         if self.rnd:
-            self.rnd.predictor.load_state_dict(model_params[1])
+            self.rnd.predictor.load_state_dict(model_params[2])
 
     def reduce_parameters(self) -> None:
         """Collect gradients from all GPUs and average them.

--- a/rsl_rl/models/cnn_model.py
+++ b/rsl_rl/models/cnn_model.py
@@ -119,9 +119,9 @@ class CNNModel(MLPModel):
         latent_1d = super().get_latent(obs)
         # Process 2D observation groups with CNNs
         latent_cnn_list = [self.cnns[obs_group](obs[obs_group]) for obs_group in self.obs_groups_2d]
-        latend_cnn = torch.cat(latent_cnn_list, dim=-1)
+        latent_cnn = torch.cat(latent_cnn_list, dim=-1)
         # Concatenate 1D and CNN latents
-        return torch.cat([latent_1d, latend_cnn], dim=-1)
+        return torch.cat([latent_1d, latent_cnn], dim=-1)
 
     def as_jit(self) -> nn.Module:
         """Return a version of the model compatible with Torch JIT export."""

--- a/rsl_rl/modules/rnn.py
+++ b/rsl_rl/modules/rnn.py
@@ -62,7 +62,7 @@ class RNN(nn.Module):
                 else:
                     self.hidden_state[..., dones == 1, :] = 0.0
             else:
-                NotImplementedError(
+                raise NotImplementedError(
                     "Resetting the hidden state of done environments with a custom hidden state is not implemented"
                 )
 


### PR DESCRIPTION
## Summary

Fixes three independent bugs found during code review:

- **`rnn.py`**: `NotImplementedError` is constructed but never raised in `RNN.reset()`, causing silent failure when resetting hidden state of done environments with a custom hidden state
- **`ppo.py`**: `broadcast_parameters()` loads `model_params[1]` (critic state) into the RND predictor instead of `model_params[2]` (its own state), corrupting RND weights during multi-GPU distributed training
- **`cnn_model.py`**: Variable name typo `latend_cnn` -> `latent_cnn` in `CNNModel.get_latent()`

## Changes

All three fixes are minimal and self-contained:

1. Add `raise` keyword before `NotImplementedError(...)` in `rnn.py:65`
2. Change `model_params[1]` to `model_params[2]` in `ppo.py:516`
3. Rename `latend_cnn` to `latent_cnn` in `cnn_model.py:122-124`

## Test plan

- All 25 existing tests pass
- Each fix is a one-line change with no behavioral side effects beyond correctness