### PR TITLE
Fix mutable default arguments and replace assertions with proper exceptions

### DIFF
--- a/rsl_rl/extensions/rnd.py
+++ b/rsl_rl/extensions/rnd.py
@@ -200,7 +200,8 @@ def resolve_rnd_config(alg_cfg: dict, obs: TensorDict, obs_groups: dict[str, lis
         # Get dimension of rnd gated state
         num_rnd_state = 0
         for obs_group in obs_groups["rnd_state"]:
-            assert len(obs[obs_group].shape) == 2, "The RND module only supports 1D observations."
+            if len(obs[obs_group].shape) != 2:
+                raise ValueError(f"The RND module only supports 1D observations, got shape {obs[obs_group].shape} for '{obs_group}'.")
             num_rnd_state += obs[obs_group].shape[-1]
         # Add rnd gated state to config
         alg_cfg["rnd_cfg"]["num_states"] = num_rnd_state

--- a/rsl_rl/models/cnn_model.py
+++ b/rsl_rl/models/cnn_model.py
@@ -33,7 +33,7 @@ class CNNModel(MLPModel):
         output_dim: int,
         cnn_cfg: dict[str, dict] | dict[str, Any],
         cnns: nn.ModuleDict | dict[str, nn.Module] | None = None,
-        hidden_dims: tuple[int] | list[int] = [256, 256, 256],
+        hidden_dims: tuple[int] | list[int] = (256, 256, 256),
         activation: str = "elu",
         obs_normalization: bool = False,
         stochastic: bool = False,
@@ -72,9 +72,8 @@ class CNNModel(MLPModel):
             if not all(isinstance(v, dict) for v in cnn_cfg.values()):
                 cnn_cfg = {group: cnn_cfg for group in self.obs_groups_2d}
             # Check that the number of configs matches the number of observation groups
-            assert len(cnn_cfg) == len(self.obs_groups_2d), (
-                "The number of CNN configurations must match the number of 2D observation groups."
-            )
+            if len(cnn_cfg) != len(self.obs_groups_2d):
+                raise ValueError("The number of CNN configurations must match the number of 2D observation groups.")
             # Create CNNs for each 2D observation
             cnns = {}
             for idx, obs_group in enumerate(self.obs_groups_2d):
@@ -152,7 +151,8 @@ class CNNModel(MLPModel):
             else:
                 raise ValueError(f"Invalid observation shape for {obs_group}: {obs[obs_group].shape}")
 
-        assert obs_groups_2d, "No 2D observations are provided. If this is intentional, use the MLP model instead."
+        if not obs_groups_2d:
+            raise ValueError("No 2D observations are provided. If this is intentional, use the MLP model instead.")
 
         # Store active 2D observation groups and dimensions directly as attributes
         self.obs_dims_2d = obs_dims_2d

--- a/rsl_rl/models/mlp_model.py
+++ b/rsl_rl/models/mlp_model.py
@@ -31,7 +31,7 @@ class MLPModel(nn.Module):
         obs_groups: dict[str, list[str]],
         obs_set: str,
         output_dim: int,
-        hidden_dims: tuple[int] | list[int] = [256, 256, 256],
+        hidden_dims: tuple[int] | list[int] = (256, 256, 256),
         activation: str = "elu",
         obs_normalization: bool = False,
         stochastic: bool = False,
@@ -205,7 +205,8 @@ class MLPModel(nn.Module):
         active_obs_groups = obs_groups[obs_set]
         obs_dim = 0
         for obs_group in active_obs_groups:
-            assert len(obs[obs_group].shape) == 2, "The MLP model only supports 1D observations."
+            if len(obs[obs_group].shape) != 2:
+                raise ValueError(f"The MLP model only supports 1D observations, got shape {obs[obs_group].shape} for '{obs_group}'.")
             obs_dim += obs[obs_group].shape[-1]
         return active_obs_groups, obs_dim
 

--- a/rsl_rl/models/rnn_model.py
+++ b/rsl_rl/models/rnn_model.py
@@ -31,7 +31,7 @@ class RNNModel(MLPModel):
         obs_groups: dict[str, list[str]],
         obs_set: str,
         output_dim: int,
-        hidden_dims: tuple[int] | list[int] = [256, 256, 256],
+        hidden_dims: tuple[int] | list[int] = (256, 256, 256),
         activation: str = "elu",
         obs_normalization: bool = False,
         stochastic: bool = False,


### PR DESCRIPTION
## Summary

- Replaced mutable list defaults `[256, 256, 256]` with tuples `(256, 256, 256)` in `MLPModel`, `CNNModel`, and `RNNModel` constructors to prevent potential shared state across instances.
- Replaced `assert` statements used for input validation with `raise ValueError(...)` in `MLPModel._get_obs_dim`, `CNNModel._get_obs_dim`, `CNNModel.__init__`, and `resolve_rnd_config`, since assertions are silently stripped when running with `python -O` (optimized mode).