### PR TITLE
Fix shared CNN modules in _OnnxCNNModel and _TorchCNNModel

### DIFF
--- a/rsl_rl/models/cnn_model.py
+++ b/rsl_rl/models/cnn_model.py
@@ -168,7 +168,7 @@ class _TorchCNNModel(nn.Module):
         super().__init__()
         self.obs_normalizer = copy.deepcopy(model.obs_normalizer)
         # Convert ModuleDict to ModuleList for ordered iteration
-        self.cnns = nn.ModuleList([model.cnns[g] for g in model.obs_groups_2d])
+        self.cnns = nn.ModuleList([copy.deepcopy(model.cnns[g]) for g in model.obs_groups_2d])
         self.mlp = copy.deepcopy(model.mlp)
         if model.distribution is not None:
             self.deterministic_output = model.distribution.as_deterministic_output_module()
@@ -204,7 +204,7 @@ class _OnnxCNNModel(nn.Module):
         self.verbose = verbose
         self.obs_normalizer = copy.deepcopy(model.obs_normalizer)
         # Convert ModuleDict to ModuleList for ordered iteration
-        self.cnns = nn.ModuleList([model.cnns[g] for g in model.obs_groups_2d])
+        self.cnns = nn.ModuleList([copy.deepcopy(model.cnns[g]) for g in model.obs_groups_2d])
         self.mlp = copy.deepcopy(model.mlp)
         if model.distribution is not None:
             self.deterministic_output = model.distribution.as_deterministic_output_module()


### PR DESCRIPTION
`_OnnxCNNModel` and `_TorchCNNModel` were taking direct references to the original model's CNN modules instead of deep-copying them. This caused `.to("cpu")` on an export wrapper to move the training model's CNN weights off the GPU, triggering a device mismatch `RuntimeError` on the next forward pass.

Fix: wrap each CNN with `copy.deepcopy(...)`, consistent with how `obs_normalizer` and `mlp` are already handled.

Fixes #188.