### PR TITLE
fix(wandb): allow config update when resuming run with same run_id

### DIFF
--- a/rsl_rl/utils/wandb_utils.py
+++ b/rsl_rl/utils/wandb_utils.py
@@ -51,11 +51,11 @@ class WandbSummaryWriter(SummaryWriter):
 
     def store_config(self, env_cfg: dict | object, train_cfg: dict) -> None:
         """Upload environment and training configuration to W&B."""
-        wandb.config.update({"train_cfg": train_cfg})
+        wandb.config.update({"train_cfg": train_cfg}, allow_val_change=True)
         try:
-            wandb.config.update({"env_cfg": env_cfg.to_dict()})  # type: ignore
+            wandb.config.update({"env_cfg": env_cfg.to_dict()}, allow_val_change=True)  # type: ignore
         except Exception:
-            wandb.config.update({"env_cfg": asdict(env_cfg)})  # type: ignore
+            wandb.config.update({"env_cfg": asdict(env_cfg)}, allow_val_change=True)  # type: ignore
 
     def add_scalar(
         self,


### PR DESCRIPTION
## Problem

I faced this behavior when I was using mjlab.
When resuming a wandb run with a fixed run_id (e.g. by setting `WANDB_RUN_ID` and `WANDB_RESUME=allow`), `store_config()` in `wandb_utils.py` calls `wandb.config.update()` to write `env_cfg` and `runner_cfg`. Since the config keys already exist from the previous run, wandb raises a `ConfigError` and training crashes:

```
wandb.sdk.lib.config_util.ConfigError: Attempted to change value of key "env_cfg" from {...} to {...}
If you really want to do this, pass allow_val_change=True to config.update()
```

## Reproduction

```python
import os
os.environ["WANDB_RUN_ID"] = "my-fixed-run-id"
os.environ["WANDB_RESUME"] = "allow"
# run training twice → crashes on second run
```

## Fix

Added `allow_val_change=True` to all `wandb.config.update()` calls in `rsl_rl/utils/wandb_utils.py`.

---

If this behavior is intentional (i.e. to prevent re-running with the same run path), feel free to ignore and close this PR.