### PR TITLE
Add Torch compile for PPO and Distillation

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -77,6 +77,11 @@ Currently, RSL-RL implements two runner classes:
      - bool
      - ``True``
      - Whether to check for NaN values coming from the environment.
+   * - ``torch_compile_mode``
+     - str | None
+     - ``None``
+     - Compile mode for the PyTorch models to accelerate training.
+       Valid values: ``None``, ``"default"``, ``"max-autotune-no-cudagraphs"``.
    * - ``algorithm``
      - dict
      - required

--- a/rsl_rl/algorithms/distillation.py
+++ b/rsl_rl/algorithms/distillation.py
@@ -13,7 +13,7 @@ from tensordict import TensorDict
 from rsl_rl.env import VecEnv
 from rsl_rl.models import MLPModel
 from rsl_rl.storage import RolloutStorage
-from rsl_rl.utils import resolve_callable, resolve_obs_groups, resolve_optimizer
+from rsl_rl.utils import compile_model, resolve_callable, resolve_obs_groups, resolve_optimizer
 
 
 class Distillation:
@@ -60,6 +60,11 @@ class Distillation:
         # Distillation components
         self.student = student.to(self.device)
         self.teacher = teacher.to(self.device)
+
+        # Handles to the uncompiled modules for state_dict operations and export. If compilation is disabled, these
+        # simply alias ``self.student`` / ``self.teacher``.
+        self._raw_student = self.student
+        self._raw_teacher = self.teacher
 
         # Create the optimizer
         self.optimizer = resolve_optimizer(optimizer)(self.student.parameters(), lr=learning_rate)  # type: ignore
@@ -180,8 +185,8 @@ class Distillation:
     def save(self) -> dict:
         """Return a dict of all models for saving."""
         saved_dict = {
-            "student_state_dict": self.student.state_dict(),
-            "teacher_state_dict": self.teacher.state_dict(),
+            "student_state_dict": self._raw_student.state_dict(),
+            "teacher_state_dict": self._raw_teacher.state_dict(),
             "optimizer_state_dict": self.optimizer.state_dict(),
         }
         return saved_dict
@@ -201,9 +206,9 @@ class Distillation:
 
         # Load the specified models
         if load_cfg.get("student"):
-            self.student.load_state_dict(loaded_dict["student_state_dict"], strict=strict)
+            self._raw_student.load_state_dict(loaded_dict["student_state_dict"], strict=strict)
         if load_cfg.get("teacher"):
-            self.teacher.load_state_dict(
+            self._raw_teacher.load_state_dict(
                 loaded_dict.get("teacher_state_dict") or loaded_dict["actor_state_dict"], strict=strict
             )
             self.teacher_loaded = True
@@ -213,7 +218,18 @@ class Distillation:
 
     def get_policy(self) -> MLPModel:
         """Get the policy model."""
-        return self.student
+        return self._raw_student
+
+    def compile(self, mode: str | None = None) -> None:
+        """Compile student and teacher with ``torch.compile``.
+
+        See :func:`~rsl_rl.utils.compile_model` for the set of accepted modes.
+
+        Args:
+            mode: ``torch.compile`` mode. Defaults to ``None``, in which case compilation is disabled.
+        """
+        self.student = compile_model(self._raw_student, mode)  # type: ignore
+        self.teacher = compile_model(self._raw_teacher, mode)  # type: ignore
 
     @staticmethod
     def construct_algorithm(obs: TensorDict, env: VecEnv, cfg: dict, device: str) -> Distillation:
@@ -253,17 +269,20 @@ class Distillation:
             student, teacher, storage, device=device, **cfg["algorithm"], multi_gpu_cfg=cfg["multi_gpu"]
         )
 
+        # Compile the algorithm's models if requested
+        alg.compile(cfg.get("torch_compile_mode"))
+
         return alg
 
     def broadcast_parameters(self) -> None:
         """Broadcast model parameters to all GPUs."""
         # Obtain the model parameters on current GPU
-        model_params = [self.student.state_dict(), self.teacher.state_dict()]
+        model_params = [self._raw_student.state_dict(), self._raw_teacher.state_dict()]
         # Broadcast the model parameters
         torch.distributed.broadcast_object_list(model_params, src=0)
         # Load the model parameters on all GPUs from source GPU
-        self.student.load_state_dict(model_params[0])
-        self.teacher.load_state_dict(model_params[1])
+        self._raw_student.load_state_dict(model_params[0])
+        self._raw_teacher.load_state_dict(model_params[1])
 
     def reduce_parameters(self) -> None:
         """Collect gradients from all GPUs and average them.

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -16,7 +16,7 @@ from rsl_rl.env import VecEnv
 from rsl_rl.extensions import RandomNetworkDistillation, resolve_rnd_config, resolve_symmetry_config
 from rsl_rl.models import MLPModel
 from rsl_rl.storage import RolloutStorage
-from rsl_rl.utils import resolve_callable, resolve_obs_groups, resolve_optimizer
+from rsl_rl.utils import compile_model, resolve_callable, resolve_obs_groups, resolve_optimizer
 
 
 class PPO:
@@ -111,6 +111,11 @@ class PPO:
         # PPO components
         self.actor = actor.to(self.device)
         self.critic = critic.to(self.device)
+
+        # Handles to the uncompiled modules for state_dict operations and export. If compilation is disabled, these
+        # simply alias ``self.actor`` / ``self.critic``.
+        self._raw_actor = self.actor
+        self._raw_critic = self.critic
 
         # Create the optimizer
         self.optimizer = resolve_optimizer(optimizer)(
@@ -432,8 +437,8 @@ class PPO:
     def save(self) -> dict:
         """Return a dict of all models for saving."""
         saved_dict = {
-            "actor_state_dict": self.actor.state_dict(),
-            "critic_state_dict": self.critic.state_dict(),
+            "actor_state_dict": self._raw_actor.state_dict(),
+            "critic_state_dict": self._raw_critic.state_dict(),
             "optimizer_state_dict": self.optimizer.state_dict(),
         }
         if self.rnd:
@@ -455,9 +460,9 @@ class PPO:
 
         # Load the specified models
         if load_cfg.get("actor"):
-            self.actor.load_state_dict(loaded_dict["actor_state_dict"], strict=strict)
+            self._raw_actor.load_state_dict(loaded_dict["actor_state_dict"], strict=strict)
         if load_cfg.get("critic"):
-            self.critic.load_state_dict(loaded_dict["critic_state_dict"], strict=strict)
+            self._raw_critic.load_state_dict(loaded_dict["critic_state_dict"], strict=strict)
         if load_cfg.get("optimizer"):
             self.optimizer.load_state_dict(loaded_dict["optimizer_state_dict"])
         if load_cfg.get("rnd") and self.rnd:
@@ -467,7 +472,18 @@ class PPO:
 
     def get_policy(self) -> MLPModel:
         """Get the policy model."""
-        return self.actor
+        return self._raw_actor
+
+    def compile(self, mode: str | None = None) -> None:
+        """Compile actor and critic with ``torch.compile``.
+
+        See :func:`~rsl_rl.utils.compile_model` for the set of accepted modes.
+
+        Args:
+            mode: ``torch.compile`` mode. Defaults to ``None``, in which case compilation is disabled.
+        """
+        self.actor = compile_model(self._raw_actor, mode)  # type: ignore
+        self.critic = compile_model(self._raw_critic, mode)  # type: ignore
 
     @staticmethod
     def construct_algorithm(obs: TensorDict, env: VecEnv, cfg: dict, device: str) -> PPO:
@@ -503,19 +519,22 @@ class PPO:
         # Initialize the algorithm
         alg: PPO = alg_class(actor, critic, storage, device=device, **cfg["algorithm"], multi_gpu_cfg=cfg["multi_gpu"])
 
+        # Compile the algorithm's models if requested
+        alg.compile(cfg.get("torch_compile_mode"))
+
         return alg
 
     def broadcast_parameters(self) -> None:
         """Broadcast model parameters to all GPUs."""
         # Obtain the model parameters on current GPU
-        model_params = [self.actor.state_dict(), self.critic.state_dict()]
+        model_params = [self._raw_actor.state_dict(), self._raw_critic.state_dict()]
         if self.rnd:
             model_params.append(self.rnd.predictor.state_dict())
         # Broadcast the model parameters
         torch.distributed.broadcast_object_list(model_params, src=0)
         # Load the model parameters on all GPUs from source GPU
-        self.actor.load_state_dict(model_params[0])
-        self.critic.load_state_dict(model_params[1])
+        self._raw_actor.load_state_dict(model_params[0])
+        self._raw_critic.load_state_dict(model_params[1])
         if self.rnd:
             self.rnd.predictor.load_state_dict(model_params[2])
 

--- a/rsl_rl/utils/__init__.py
+++ b/rsl_rl/utils/__init__.py
@@ -7,6 +7,7 @@
 
 from .utils import (
     check_nan,
+    compile_model,
     get_param,
     resolve_callable,
     resolve_nn_activation,
@@ -18,6 +19,7 @@ from .utils import (
 
 __all__ = [
     "check_nan",
+    "compile_model",
     "get_param",
     "resolve_callable",
     "resolve_nn_activation",

--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -292,6 +292,32 @@ def check_nan(obs: TensorDict, rewards: torch.Tensor, dones: torch.Tensor) -> No
         )
 
 
+def compile_model(model: torch.nn.Module, mode: str | None = None) -> torch.nn.Module:
+    """Wrap a model with :func:`torch.compile`, validating the compile mode.
+
+    Args:
+        model: The model to compile.
+        mode: The :func:`torch.compile` mode. CUDA-graph modes (``"reduce-overhead"``, ``"max-autotune"``)
+            are rejected because they are incompatible with the multi-model forward patterns used by the algorithms
+            (graph replay overwrites the previous call's output buffer). Use ``"default"`` or
+            ``"max-autotune-no-cudagraphs"`` instead. Defaults to ``None``, in which case compilation is disabled.
+
+    Returns:
+        The compiled model, or the original model if ``mode`` is ``None``.
+
+    Raises:
+        ValueError: If ``mode`` is one of the unsupported CUDA-graph modes.
+    """
+    if mode is None:
+        return model
+    if mode in ("reduce-overhead", "max-autotune"):
+        raise ValueError(
+            f"torch_compile_mode='{mode}' uses CUDA graphs which are incompatible with algorithms' multi-model forward "
+            f"pattern. Use 'default' or 'max-autotune-no-cudagraphs', or set to None to disable."
+        )
+    return torch.compile(model, mode=mode)  # type: ignore
+
+
 def split_and_pad_trajectories(
     tensor: torch.Tensor | TensorDict, dones: torch.Tensor
 ) -> tuple[torch.Tensor | TensorDict, torch.Tensor]:

--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -297,10 +297,10 @@ def compile_model(model: torch.nn.Module, mode: str | None = None) -> torch.nn.M
 
     Args:
         model: The model to compile.
-        mode: The :func:`torch.compile` mode. CUDA-graph modes (``"reduce-overhead"``, ``"max-autotune"``)
-            are rejected because they are incompatible with the multi-model forward patterns used by the algorithms
-            (graph replay overwrites the previous call's output buffer). Use ``"default"`` or
-            ``"max-autotune-no-cudagraphs"`` instead. Defaults to ``None``, in which case compilation is disabled.
+        mode: The :func:`torch.compile` mode. CUDA-graph modes (``"reduce-overhead"``, ``"max-autotune"``) are rejected
+        because they are incompatible with the multi-model forward patterns used by the algorithms (graph replay
+        overwrites the previous call's output buffer). Use ``"default"`` or ``"max-autotune-no-cudagraphs"`` instead.
+        Defaults to ``None``, in which case compilation is disabled.
 
     Returns:
         The compiled model, or the original model if ``mode`` is ``None``.

--- a/rsl_rl/utils/utils.py
+++ b/rsl_rl/utils/utils.py
@@ -312,8 +312,8 @@ def compile_model(model: torch.nn.Module, mode: str | None = None) -> torch.nn.M
         return model
     if mode in ("reduce-overhead", "max-autotune"):
         raise ValueError(
-            f"torch_compile_mode='{mode}' uses CUDA graphs which are incompatible with algorithms' multi-model forward "
-            f"pattern. Use 'default' or 'max-autotune-no-cudagraphs', or set to None to disable."
+            f"torch_compile_mode='{mode}' uses CUDA graphs which are incompatible with the algorithms' multi-model "
+            f"forward pattern. Use 'default' or 'max-autotune-no-cudagraphs', or set to None to disable."
         )
     return torch.compile(model, mode=mode)  # type: ignore
 


### PR DESCRIPTION
This PR implements Torch compilation for the models of PPO and Distillation to accelerate training. It is based on #196 and #198.

In contrast to #198, it implements the compilation on algorithm level instead of runner level, to avoid exposing algorithm-specifics to the runner.