### PR TITLE
Add clip and constant std functionalities to Gaussian Distribution

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ title: "RSL-RL: A Learning Library for Robotics Research"
 message: "If you use this work, please cite the following paper."
 repository-code: "https://github.com/leggedrobotics/rsl_rl"
 license: BSD-3-Clause
-version: 5.1.0
+version: 5.2.0
 type: software
 authors:
   - family-names: Schwarke

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ Please keep the lists sorted alphabetically.
 ## Contributors
 
 * Bikram Pandit
+* Emilio Palma
 * Eric Vollenweider
 * Fabian Jenelten
 * Lorenzo Terenzi

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -295,7 +295,13 @@ MLPModel
 The  ``distribution_cfg`` dictionary contains all parameters required by a specific distribution. RSL-RL implements two
 distributions by default: A simple Gaussian distribution (:class:`~rsl_rl.modules.distribution.GaussianDistribution`) 
 and a Gaussian distribution with state-dependent standard deviation 
-(:class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution`). Both require the same parameters:
+(:class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution`).
+
+GaussianDistribution
+  ^^^^^^^^^^^^^^^^^^^^
+
+The :class:`~rsl_rl.modules.distribution.GaussianDistribution` implements a multivariate Gaussian (Normal) distribution with diagonal covariance and **state-independent** standard deviation. 
+This means the standard deviation is a learnable parameter, but does not depend on the model input (i.e., it is global for all states). The main options are:
 
 .. list-table::
    :header-rows: 1
@@ -308,15 +314,54 @@ and a Gaussian distribution with state-dependent standard deviation
    * - ``class_name``
      - str
      - required
-     - Distribution class name. Valid values: ``"GaussianDistribution"``, ``"HeteroscedasticGaussianDistribution"``.
+     - Must be ``"GaussianDistribution"``.
    * - ``init_std``
      - float
      - ``1.0``
-     - Initial standard deviation.
+     - Initial standard deviation for all action dimensions.
    * - ``std_type``
      - str
      - ``"scalar"``
-     - Parameterization of the standard deviation. Valid values: ``"scalar"``, ``"log"``.
+     - Parameterization of the standard deviation. ``"scalar"`` means std is stored directly; ``"log"`` means std is stored in log-space and exponentiated. Both are learnable if ``learn_std`` is True.
+   * - ``std_range``
+     - tuple[float, float]
+     - ``(1e-6, 1e6)``
+     - Minimum and maximum allowed values for the standard deviation (clamped for numerical stability).
+   * - ``learn_std``
+     - bool
+     - ``True``
+     - Whether the standard deviation is learnable (True) or fixed (False).
+
+HeteroscedasticGaussianDistribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution` implements a multivariate Gaussian (Normal) distribution with diagonal covariance and **state-dependent** standard deviation. 
+Here, both the mean and standard deviation are produced by the model (typically as two heads of the MLP output). The main options are:
+
+.. list-table::
+   :header-rows: 1
+   :class: no-wrap-type-column
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``class_name``
+     - str
+     - required
+     - Must be ``"HeteroscedasticGaussianDistribution"``.
+   * - ``init_std``
+     - float
+     - ``1.0``
+     - Initial standard deviation (used to initialize the std head bias).
+   * - ``std_type``
+     - str
+     - ``"scalar"``
+     - Parameterization of the standard deviation. ``"scalar"`` means std is output directly; ``"log"`` means the model outputs log-std, which is exponentiated.
+   * - ``std_range``
+     - tuple[float, float]
+     - ``(1e-6, 1e6)``
+     - Minimum and maximum allowed values for the standard deviation (clamped for numerical stability).
 
 RNNModel
 ^^^^^^^^

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -52,7 +52,8 @@ Currently, RSL-RL implements two runner classes:
    * - ``obs_groups``
      - dict[str, list[str]]
      - required
-     - Mapping from observation sets to observation groups coming from the environment. See :ref:`here <observation-configuration>` for more details.
+     - Mapping from observation sets to observation groups coming from the environment. See :ref:`here
+       <observation-configuration>` for more details.
    * - ``save_interval``
      - int
      - required
@@ -290,78 +291,7 @@ MLPModel
      - dict | None
      - ``None``
      - Optional output distribution configuration. If provided, the model can output stochastic values sampled from 
-       the distribution.
-
-The  ``distribution_cfg`` dictionary contains all parameters required by a specific distribution. RSL-RL implements two
-distributions by default: A simple Gaussian distribution (:class:`~rsl_rl.modules.distribution.GaussianDistribution`) 
-and a Gaussian distribution with state-dependent standard deviation 
-(:class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution`).
-
-GaussianDistribution
-  ^^^^^^^^^^^^^^^^^^^^
-
-The :class:`~rsl_rl.modules.distribution.GaussianDistribution` implements a multivariate Gaussian (Normal) distribution with diagonal covariance and **state-independent** standard deviation. 
-This means the standard deviation is a learnable parameter, but does not depend on the model input (i.e., it is global for all states). The main options are:
-
-.. list-table::
-   :header-rows: 1
-   :class: no-wrap-type-column
-
-   * - Key
-     - Type
-     - Default
-     - Description
-   * - ``class_name``
-     - str
-     - required
-     - Must be ``"GaussianDistribution"``.
-   * - ``init_std``
-     - float
-     - ``1.0``
-     - Initial standard deviation for all action dimensions.
-   * - ``std_type``
-     - str
-     - ``"scalar"``
-     - Parameterization of the standard deviation. ``"scalar"`` means std is stored directly; ``"log"`` means std is stored in log-space and exponentiated. Both are learnable if ``learn_std`` is True.
-   * - ``std_range``
-     - tuple[float, float]
-     - ``(1e-6, 1e6)``
-     - Minimum and maximum allowed values for the standard deviation (clamped for numerical stability).
-   * - ``learn_std``
-     - bool
-     - ``True``
-     - Whether the standard deviation is learnable (True) or fixed (False).
-
-HeteroscedasticGaussianDistribution
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution` implements a multivariate Gaussian (Normal) distribution with diagonal covariance and **state-dependent** standard deviation. 
-Here, both the mean and standard deviation are produced by the model (typically as two heads of the MLP output). The main options are:
-
-.. list-table::
-   :header-rows: 1
-   :class: no-wrap-type-column
-
-   * - Key
-     - Type
-     - Default
-     - Description
-   * - ``class_name``
-     - str
-     - required
-     - Must be ``"HeteroscedasticGaussianDistribution"``.
-   * - ``init_std``
-     - float
-     - ``1.0``
-     - Initial standard deviation (used to initialize the std head bias).
-   * - ``std_type``
-     - str
-     - ``"scalar"``
-     - Parameterization of the standard deviation. ``"scalar"`` means std is output directly; ``"log"`` means the model outputs log-std, which is exponentiated.
-   * - ``std_range``
-     - tuple[float, float]
-     - ``(1e-6, 1e6)``
-     - Minimum and maximum allowed values for the standard deviation (clamped for numerical stability).
+       the specified distribution.
 
 RNNModel
 ^^^^^^^^
@@ -485,6 +415,75 @@ configuration includes the following parameters:
      - bool
      - ``True``
      - Whether to flatten the output tensor.
+
+
+Distribution Configuration
+--------------------------
+
+RSL-RL implements two distributions that enable stochastic model outputs: A
+:class:`~rsl_rl.modules.distribution.GaussianDistribution` and a
+:class:`~rsl_rl.modules.distribution.HeteroscedasticGaussianDistribution` with state-dependent standard deviation, which
+may be configured as follows.
+
+GaussianDistribution
+^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :class: no-wrap-type-column
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``class_name``
+     - str
+     - required
+     - Distribution class name. Valid values: ``"GaussianDistribution"``.
+   * - ``init_std``
+     - float
+     - ``1.0``
+     - Initial standard deviation for all dimensions.
+   * - ``std_range``
+     - tuple[float, float]
+     - ``(1e-6, 1e6)``
+     - Minimum and maximum allowed values for the standard deviation for numerical stability.
+   * - ``std_type``
+     - str
+     - ``"scalar"``
+     - Whether the standard deviation is stored directly or in log-space. Valid values: ``"scalar"``, ``"log"``.
+   * - ``learn_std``
+     - bool
+     - ``True``
+     - Whether the standard deviation is learnable or fixed.
+
+HeteroscedasticGaussianDistribution
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :class: no-wrap-type-column
+
+   * - Key
+     - Type
+     - Default
+     - Description
+   * - ``class_name``
+     - str
+     - required
+     - Distribution class name. Valid values: ``"HeteroscedasticGaussianDistribution"``.
+   * - ``init_std``
+     - float
+     - ``1.0``
+     - Initial standard deviation (used to initialize the std head bias).
+   * - ``std_range``
+     - tuple[float, float]
+     - ``(1e-6, 1e6)``
+     - Minimum and maximum allowed values for the standard deviation for numerical stability.
+   * - ``std_type``
+     - str
+     - ``"scalar"``
+     - Whether the standard deviation is stored directly or in log-space. Valid values: ``"scalar"``, ``"log"``.
 
 Extension Configuration
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rsl-rl-lib"
-version = "5.1.0"
+version = "5.2.0"
 keywords = ["reinforcement-learning", "robotics"]
 maintainers = [
   { name="Clemens Schwarke", email="cschwarke@ethz.ch" },

--- a/rsl_rl/modules/distribution.py
+++ b/rsl_rl/modules/distribution.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.distributions import Normal
@@ -141,6 +142,8 @@ class GaussianDistribution(Distribution):
         output_dim: int,
         init_std: float = 1.0,
         std_type: str = "scalar",
+        std_range: tuple[float, float] = (1e-6, 1e6),
+        learn_std: bool = True,
     ) -> None:
         """Initialize the Gaussian distribution module.
 
@@ -148,17 +151,24 @@ class GaussianDistribution(Distribution):
             output_dim: Dimension of the action/output space.
             init_std: Initial standard deviation.
             std_type: Parameterization of the standard deviation: "scalar" or "log".
+            std_range: Range for the standard deviation. Should be a tuple (min, max) values to clamp the std.
+            learn_std: Whether the standard deviation should be learnable. If False, it will be fixed to init_std.
         """
         super().__init__(output_dim)
         self.std_type = std_type
 
         # Learnable std parameters
         if std_type == "scalar":
-            self.std_param = nn.Parameter(init_std * torch.ones(output_dim))
+            self.std_param = nn.Parameter(init_std * torch.ones(output_dim), requires_grad=learn_std)
         elif std_type == "log":
-            self.log_std_param = nn.Parameter(torch.log(init_std * torch.ones(output_dim)))
+            self.log_std_param = nn.Parameter(torch.log(init_std * torch.ones(output_dim)), requires_grad=learn_std)
         else:
             raise ValueError(f"Unknown standard deviation type: {std_type}. Should be 'scalar' or 'log'.")
+
+        # Clamp the std range to ensure numerical stability and store log space range if needed
+        self.std_range = list(std_range)
+        self.std_range[0] = max(self.std_range[0], 1e-6)  # Avoid zero std for numerical stability
+        self.log_std_range = [float(np.log(self.std_range[0])), float(np.log(self.std_range[1]))]
 
         # Internal torch distribution (populated by update())
         self._distribution: Normal | None = None
@@ -170,9 +180,10 @@ class GaussianDistribution(Distribution):
         """Update the Gaussian distribution from MLP output."""
         mean = mlp_output
         if self.std_type == "scalar":
-            std = self.std_param.expand_as(mean)
+            std = self.std_param.clamp(self.std_range[0], self.std_range[1])
         elif self.std_type == "log":
-            std = torch.exp(self.log_std_param).expand_as(mean)
+            log_std = self.log_std_param.clamp(self.log_std_range[0], self.log_std_range[1])
+            std = torch.exp(log_std)
         self._distribution = Normal(mean, std)
 
     def sample(self) -> torch.Tensor:
@@ -238,6 +249,7 @@ class HeteroscedasticGaussianDistribution(GaussianDistribution):
         output_dim: int,
         init_std: float = 1.0,
         std_type: str = "scalar",
+        std_range: tuple[float, float] = (1e-6, 1e6),
     ) -> None:
         """Initialize the heteroscedastic Gaussian distribution module.
 
@@ -245,6 +257,7 @@ class HeteroscedasticGaussianDistribution(GaussianDistribution):
             output_dim: Dimension of the action/output space.
             init_std: Initial standard deviation (used to initialize MLP std head bias).
             std_type: Parameterization of the standard deviation: "scalar" or "log".
+            std_range: Range for the standard deviation. Should be a tuple (min, max) values to clamp the std.
         """
         # Skip GaussianDistribution.__init__ to avoid creating unnecessary learnable std parameters.
         Distribution.__init__(self, output_dim)
@@ -253,6 +266,11 @@ class HeteroscedasticGaussianDistribution(GaussianDistribution):
 
         if std_type not in ("scalar", "log"):
             raise ValueError(f"Unknown standard deviation type: {std_type}. Should be 'scalar' or 'log'.")
+
+        # Clamp the std range to ensure numerical stability and store log space range if needed
+        self.std_range = list(std_range)
+        self.std_range[0] = max(self.std_range[0], 1e-6)  # Avoid zero std for numerical stability
+        self.log_std_range = [float(np.log(self.std_range[0])), float(np.log(self.std_range[1]))]
 
         # Internal torch distribution (populated by update())
         self._distribution: Normal | None = None
@@ -264,8 +282,10 @@ class HeteroscedasticGaussianDistribution(GaussianDistribution):
         """Update the Gaussian distribution from MLP output."""
         if self.std_type == "scalar":
             mean, std = torch.unbind(mlp_output, dim=-2)
+            std = torch.clamp(std, self.std_range[0], self.std_range[1])
         elif self.std_type == "log":
             mean, log_std = torch.unbind(mlp_output, dim=-2)
+            log_std = torch.clamp(log_std, self.log_std_range[0], self.log_std_range[1])
             std = torch.exp(log_std)
         self._distribution = Normal(mean, std)
 

--- a/rsl_rl/modules/distribution.py
+++ b/rsl_rl/modules/distribution.py
@@ -130,19 +130,23 @@ class Distribution(nn.Module):
 
 
 class GaussianDistribution(Distribution):
-    """Gaussian (Normal) distribution module with state-independent standard deviation.
+    """Gaussian distribution module with state-independent standard deviation.
 
-    This distribution parameterizes actions using a multivariate Gaussian with diagonal covariance. The standard
-    deviation is a learnable parameter that is independent of the model input. It can be parameterized in either
-    "scalar" space (directly) or "log" space.
+    This distribution parameterizes stochastic outputs using a multivariate Gaussian with diagonal covariance. The
+    standard deviation can be a learnable parameter or a constant. It can be parameterized in either "scalar" space or
+    "log" space and is clamped to a specified range.
+
+    ..note:
+        If the standard deviation type is set to "log", the provided arguments are still interpreted in scalar space,
+        and converted to log space internally.
     """
 
     def __init__(
         self,
         output_dim: int,
         init_std: float = 1.0,
-        std_type: str = "scalar",
         std_range: tuple[float, float] = (1e-6, 1e6),
+        std_type: str = "scalar",
         learn_std: bool = True,
     ) -> None:
         """Initialize the Gaussian distribution module.
@@ -150,9 +154,9 @@ class GaussianDistribution(Distribution):
         Args:
             output_dim: Dimension of the action/output space.
             init_std: Initial standard deviation.
+            std_range: Range for the standard deviation. Should be a tuple of (min, max) values for clamping.
             std_type: Parameterization of the standard deviation: "scalar" or "log".
-            std_range: Range for the standard deviation. Should be a tuple (min, max) values to clamp the std.
-            learn_std: Whether the standard deviation should be learnable. If False, it will be fixed to init_std.
+            learn_std: Whether the standard deviation should be learnable. If False, it will be fixed to `init_std`.
         """
         super().__init__(output_dim)
         self.std_type = std_type
@@ -237,27 +241,31 @@ class GaussianDistribution(Distribution):
 
 
 class HeteroscedasticGaussianDistribution(GaussianDistribution):
-    """Gaussian (Normal) distribution module with state-dependent standard deviation.
+    """Gaussian distribution module with state-dependent standard deviation.
 
-    This distribution parameterizes actions using a multivariate Gaussian with diagonal covariance. The standard
-    deviation is output by the MLP alongside the mean, making it state-dependent (heteroscedastic). It can be
-    parameterized in either "scalar" space (directly) or "log" space.
+    This distribution parameterizes stochastic outputs using a multivariate Gaussian with diagonal covariance. The
+    standard deviation is output by the MLP alongside the mean, making it state-dependent. It can be parameterized in
+    either "scalar" space or "log" space, and is clamped to a specified range.
+
+    ..note:
+        If the standard deviation type is set to "log", the provided arguments are still interpreted in scalar space,
+        and converted to log space internally.
     """
 
     def __init__(
         self,
         output_dim: int,
         init_std: float = 1.0,
-        std_type: str = "scalar",
         std_range: tuple[float, float] = (1e-6, 1e6),
+        std_type: str = "scalar",
     ) -> None:
         """Initialize the heteroscedastic Gaussian distribution module.
 
         Args:
             output_dim: Dimension of the action/output space.
-            init_std: Initial standard deviation (used to initialize MLP std head bias).
+            init_std: Initial standard deviation (used to initialize the MLP's std head bias).
+            std_range: Range for the standard deviation. Should be a tuple of (min, max) values for clamping.
             std_type: Parameterization of the standard deviation: "scalar" or "log".
-            std_range: Range for the standard deviation. Should be a tuple (min, max) values to clamp the std.
         """
         # Skip GaussianDistribution.__init__ to avoid creating unnecessary learnable std parameters.
         Distribution.__init__(self, output_dim)

--- a/rsl_rl/modules/distribution.py
+++ b/rsl_rl/modules/distribution.py
@@ -136,7 +136,7 @@ class GaussianDistribution(Distribution):
     standard deviation can be a learnable parameter or a constant. It can be parameterized in either "scalar" space or
     "log" space and is clamped to a specified range.
 
-    ..note:
+    .. note::
         If the standard deviation type is set to "log", the provided arguments are still interpreted in scalar space,
         and converted to log space internally.
     """
@@ -247,7 +247,7 @@ class HeteroscedasticGaussianDistribution(GaussianDistribution):
     standard deviation is output by the MLP alongside the mean, making it state-dependent. It can be parameterized in
     either "scalar" space or "log" space, and is clamped to a specified range.
 
-    ..note:
+    .. note::
         If the standard deviation type is set to "log", the provided arguments are still interpreted in scalar space,
         and converted to log space internally.
     """

--- a/tests/modules/test_distribution.py
+++ b/tests/modules/test_distribution.py
@@ -96,6 +96,79 @@ class TestGaussianDistribution:
         assert mean.grad is not None, "Gradient should flow from log_prob to mean"
         assert not torch.all(mean.grad == 0), "Gradient should be non-zero"
 
+    def test_std_clamped_to_range_scalar(self) -> None:
+        """The std should be clamped to both bounds of std_range for std_type='scalar'."""
+        dim = 2
+        std_range = (0.1, 2.0)
+        # Above the upper bound.
+        dist_high = GaussianDistribution(output_dim=dim, init_std=10.0, std_type="scalar", std_range=std_range)
+        dist_high.update(torch.zeros(1, dim))
+        assert torch.allclose(dist_high.std, torch.full((1, dim), std_range[1]), atol=1e-6)
+        # Below the lower bound.
+        dist_low = GaussianDistribution(output_dim=dim, init_std=0.01, std_type="scalar", std_range=std_range)
+        dist_low.update(torch.zeros(1, dim))
+        assert torch.allclose(dist_low.std, torch.full((1, dim), std_range[0]), atol=1e-6)
+
+    def test_std_clamped_to_range_log(self) -> None:
+        """The std should be clamped to both bounds of std_range for std_type='log'."""
+        dim = 2
+        std_range = (0.1, 2.0)
+        # Above the upper bound.
+        dist_high = GaussianDistribution(output_dim=dim, init_std=10.0, std_type="log", std_range=std_range)
+        dist_high.update(torch.zeros(1, dim))
+        assert torch.allclose(dist_high.std, torch.full((1, dim), std_range[1]), atol=1e-6)
+        # Below the lower bound.
+        dist_low = GaussianDistribution(output_dim=dim, init_std=0.01, std_type="log", std_range=std_range)
+        dist_low.update(torch.zeros(1, dim))
+        assert torch.allclose(dist_low.std, torch.full((1, dim), std_range[0]), atol=1e-6)
+
+    def test_std_range_min_floor(self) -> None:
+        """The minimum of std_range should be floored to 1e-6 for numerical stability."""
+        dist = GaussianDistribution(output_dim=2, init_std=1.0, std_type="scalar", std_range=(0.0, 10.0))
+        assert dist.std_range[0] == 1e-6
+
+    def test_learn_std_scalar(self) -> None:
+        """learn_std should control whether the scalar std parameter is learnable."""
+        dim = 3
+        init_std = 0.7
+        # learn_std=True: parameter is trainable and receives non-zero gradient.
+        dist_learn = GaussianDistribution(output_dim=dim, init_std=init_std, std_type="scalar", learn_std=True)
+        assert dist_learn.std_param.requires_grad is True
+        dist_learn.update(torch.randn(2, dim))
+        sample = dist_learn.sample().detach()
+        dist_learn.log_prob(sample).sum().backward()
+        assert dist_learn.std_param.grad is not None and not torch.all(dist_learn.std_param.grad == 0)
+        # learn_std=False: parameter is frozen and receives no gradient.
+        dist_fixed = GaussianDistribution(output_dim=dim, init_std=init_std, std_type="scalar", learn_std=False)
+        assert dist_fixed.std_param.requires_grad is False
+        mean = torch.randn(2, dim, requires_grad=True)
+        dist_fixed.update(mean)
+        sample = dist_fixed.sample().detach()
+        dist_fixed.log_prob(sample).sum().backward()
+        assert dist_fixed.std_param.grad is None, "Non-learnable std should not receive gradients"
+        assert torch.allclose(dist_fixed.std_param, torch.full((dim,), init_std), atol=1e-6)
+
+    def test_learn_std_log(self) -> None:
+        """learn_std should control whether the log std parameter is learnable."""
+        dim = 3
+        init_std = 0.7
+        # learn_std=True: parameter is trainable and receives non-zero gradient.
+        dist_learn = GaussianDistribution(output_dim=dim, init_std=init_std, std_type="log", learn_std=True)
+        assert dist_learn.log_std_param.requires_grad is True
+        dist_learn.update(torch.randn(2, dim))
+        sample = dist_learn.sample().detach()
+        dist_learn.log_prob(sample).sum().backward()
+        assert dist_learn.log_std_param.grad is not None and not torch.all(dist_learn.log_std_param.grad == 0)
+        # learn_std=False: parameter is frozen and receives no gradient.
+        dist_fixed = GaussianDistribution(output_dim=dim, init_std=init_std, std_type="log", learn_std=False)
+        assert dist_fixed.log_std_param.requires_grad is False
+        mean = torch.randn(2, dim, requires_grad=True)
+        dist_fixed.update(mean)
+        sample = dist_fixed.sample().detach()
+        dist_fixed.log_prob(sample).sum().backward()
+        assert dist_fixed.log_std_param.grad is None, "Non-learnable log std should not receive gradients"
+        assert torch.allclose(dist_fixed.log_std_param, torch.log(torch.full((dim,), init_std)), atol=1e-6)
+
 
 class TestHeteroscedasticGaussianDistribution:
     """Tests for ``HeteroscedasticGaussianDistribution``."""
@@ -142,3 +215,37 @@ class TestHeteroscedasticGaussianDistribution:
         dim = 5
         dist = HeteroscedasticGaussianDistribution(output_dim=dim)
         assert dist.input_dim == [2, dim]
+
+    def test_std_clamped_to_range_scalar(self) -> None:
+        """The state-dependent std should be clamped to std_range for std_type='scalar'."""
+        dim = 3
+        dist = HeteroscedasticGaussianDistribution(
+            output_dim=dim, init_std=1.0, std_type="scalar", std_range=(0.1, 2.0)
+        )
+
+        mean_val = torch.zeros(1, dim)
+        std_val = torch.tensor([[10.0, 0.01, 1.0]])  # above, below, inside
+        mlp_output = torch.stack([mean_val, std_val], dim=-2)
+
+        dist.update(mlp_output)
+        expected = torch.tensor([[2.0, 0.1, 1.0]])
+        assert torch.allclose(dist.std, expected, atol=1e-6)
+
+    def test_std_clamped_to_range_log(self) -> None:
+        """The state-dependent std should be clamped to std_range for std_type='log'."""
+        dim = 3
+        dist = HeteroscedasticGaussianDistribution(output_dim=dim, init_std=1.0, std_type="log", std_range=(0.1, 2.0))
+
+        mean_val = torch.zeros(1, dim)
+        # log values: log(10) above, log(0.01) below, log(1) inside
+        log_std_val = torch.log(torch.tensor([[10.0, 0.01, 1.0]]))
+        mlp_output = torch.stack([mean_val, log_std_val], dim=-2)
+
+        dist.update(mlp_output)
+        expected = torch.tensor([[2.0, 0.1, 1.0]])
+        assert torch.allclose(dist.std, expected, atol=1e-6)
+
+    def test_std_range_min_floor(self) -> None:
+        """The minimum of std_range should be floored to 1e-6 for numerical stability."""
+        dist = HeteroscedasticGaussianDistribution(output_dim=2, init_std=1.0, std_type="scalar", std_range=(0.0, 10.0))
+        assert dist.std_range[0] == 1e-6


### PR DESCRIPTION
# Description
This pull request enhances the flexibility and safety of the Gaussian distributions implementation.

## Changes
- Added a `std_range` parameter to `GaussianDistribution` and `HeteroscedasticGaussianDistribution`, allowing users to clamp the standard deviation to a specified range for greater numerical stability and flexibility.
- Added a `learn_std` parameter to `GaussianDistribution` , allowing users to keep the std of the normal distribution constant across policy updates, usefull for distillation or finetuning.

Linked PR: #190