### PR TITLE
Logger: union keys across the window instead of sampling from index 0

### DIFF
--- a/rsl_rl/utils/logger.py
+++ b/rsl_rl/utils/logger.py
@@ -157,8 +157,11 @@ class Logger:
             # Log episode extras
             extras_string = ""
             if self.ep_extras:
-                # Iterate over all keys in the episode info dictionary
-                for key in self.ep_extras[0]:
+                # Union of keys across the window: avoids dropping keys that are
+                # absent from ep_extras[0] but present in later entries (e.g. when
+                # an env writes to extras["log"] only on reset steps).
+                all_keys = {k for ep_info in self.ep_extras for k in ep_info}
+                for key in all_keys:
                     infotensor = torch.tensor([], device=self.device)
                     # Iterate over all steps
                     for ep_info in self.ep_extras:

--- a/rsl_rl/utils/logger.py
+++ b/rsl_rl/utils/logger.py
@@ -157,11 +157,8 @@ class Logger:
             # Log episode extras
             extras_string = ""
             if self.ep_extras:
-                # Union of keys across the window: avoids dropping keys that are
-                # absent from ep_extras[0] but present in later entries (e.g. when
-                # an env writes to extras["log"] only on reset steps).
-                all_keys = {k for ep_info in self.ep_extras for k in ep_info}
-                for key in all_keys:
+                # Iterate over all keys in the episode info dictionary
+                for key in {k for ep_info in self.ep_extras for k in ep_info}:
                     infotensor = torch.tensor([], device=self.device)
                     # Iterate over all steps
                     for ep_info in self.ep_extras:


### PR DESCRIPTION
`ep_extras` is a list of per-step extras dicts, and contents vary across steps (e.g., Episode_Reward/* only appears on steps where an env resets). Iterating `ep_extras[0]` silently dropped any key absent from the first step. Take the union of keys so intermittent keys still get logged.