### PR TITLE
Preserve observation tensors dtype in the rollout storage

### DIFF
--- a/rsl_rl/storage/rollout_storage.py
+++ b/rsl_rl/storage/rollout_storage.py
@@ -140,7 +140,10 @@ class RolloutStorage:
 
         # Core
         self.observations = TensorDict(
-            {key: torch.zeros(num_transitions_per_env, *value.shape, device=device, dtype=value.dtype) for key, value in obs.items()},
+            {
+                key: torch.zeros(num_transitions_per_env, *value.shape, device=device, dtype=value.dtype)
+                for key, value in obs.items()
+            },
             batch_size=[num_transitions_per_env, num_envs],
             device=self.device,
         )

--- a/rsl_rl/storage/rollout_storage.py
+++ b/rsl_rl/storage/rollout_storage.py
@@ -140,7 +140,7 @@ class RolloutStorage:
 
         # Core
         self.observations = TensorDict(
-            {key: torch.zeros(num_transitions_per_env, *value.shape, device=device) for key, value in obs.items()},
+            {key: torch.zeros(num_transitions_per_env, *value.shape, device=device, dtype=value.dtype) for key, value in obs.items()},
             batch_size=[num_transitions_per_env, num_envs],
             device=self.device,
         )

--- a/rsl_rl/storage/rollout_storage.py
+++ b/rsl_rl/storage/rollout_storage.py
@@ -141,7 +141,7 @@ class RolloutStorage:
         # Core
         self.observations = TensorDict(
             {
-                key: torch.zeros(num_transitions_per_env, *value.shape, device=device, dtype=value.dtype)
+                key: torch.zeros(num_transitions_per_env, *value.shape, dtype=value.dtype, device=device)
                 for key, value in obs.items()
             },
             batch_size=[num_transitions_per_env, num_envs],


### PR DESCRIPTION
Currently, observation tensors in the rollout storage are initialised with the default dtype. This could lead to unintentional type conversions and increased memory consumption (for example, in our project observations can be rgb images with dtype `torch.uint8`). This PR ensures that the observation tensors in the rollout storage have dtype consistent with the observations from the environment.