### PR TITLE
docs: config schema by release + ROCm PyTorch note + Chrono-style example YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ If you use RSL-RL in your research, please cite the [paper](https://arxiv.org/ab
   year={2025}
 }
 ```
+
+## Version matrix (Chrono / Gymnasium integrations)
+
+| `rsl-rl-lib` | Config schema | Notes |
+|--------------|---------------|-------|
+| **2.3.x** (e.g. 2.3.3) | Top-level `policy` with `class_name: ActorCritic`; flat `algorithm` dict | Used by [gym-chrono](https://github.com/projectchrono/gym-chrono) Chrono 10 reproducers and [Chrono::Ray](https://github.com/uwsbel/chrono-ray) quadruped-style scripts. Example: `config/examples/chrono_gymnasium_ppo_2x.yaml`. |
+| **5.x / main** | `actor` + `critic` `MLPModel` blocks; required `obs_groups`; `TensorDict` observations | See [configuration guide](docs/guide/configuration.rst). Example: `config/examples/chrono_gymnasium_ppo_current.yaml`. |
+
+When upgrading `rsl-rl-lib`, diff your YAML against the table above — field renames are **not** backward compatible between the 2.x ActorCritic layout and the current MLPModel layout.
+
+## PyTorch on AMD ROCm
+
+RSL-RL uses generic `torch` ops (no custom CUDA extensions in the default PPO path). Training on **AMD Instinct** GPUs works when you install **PyTorch built for ROCm** and pass `device="cuda"` to `OnPolicyRunner` (PyTorch uses the HIP/ROCm backend).
+
+```bash
+pip install rsl-rl-lib==2.3.3   # or your pinned minor
+pip install --force-reinstall torch torchvision \
+    --index-url https://download.pytorch.org/whl/rocm6.2
+```
+
+Use a ROCm wheel index that matches your driver (`rocm6.2`, `rocm6.3`, etc.). After installing RSL-RL, re-pin ROCm `torch` if pip resolves a CUDA build.
+
+**Related:** [gym-chrono](https://github.com/projectchrono/gym-chrono) README (version pins, Ray + ROCm layout); [chrono-ray](https://github.com/uwsbel/chrono-ray) `docs/AMD_ROCM.md` for Ray bootstrap before `import ray`.

--- a/config/examples/chrono_gymnasium_ppo_2x.yaml
+++ b/config/examples/chrono_gymnasium_ppo_2x.yaml
@@ -1,0 +1,32 @@
+# Chrono + Gymnasium PPO — rsl-rl-lib 2.3.x (ActorCritic schema)
+#
+# Example training config for Chrono-Gymnasium-style locomotion reproducers
+# (e.g. gym-chrono ChronoViperWalk-v0, Chrono::Ray quadruped workflows).
+#
+#   import yaml
+#   train_cfg = yaml.safe_load(open("config/examples/chrono_gymnasium_ppo_2x.yaml"))
+
+algorithm:
+  class_name: PPO
+  value_loss_coef: 1.0
+  use_clipped_value_loss: true
+  clip_param: 0.2
+  entropy_coef: 0.005
+  num_learning_epochs: 5
+  num_mini_batches: 4
+  learning_rate: 0.001
+  schedule: adaptive
+  gamma: 0.99
+  lam: 0.95
+  desired_kl: 0.01
+  max_grad_norm: 1.0
+policy:
+  class_name: ActorCritic
+  actor_hidden_dims: [512, 256, 128]
+  critic_hidden_dims: [512, 256, 128]
+  activation: elu
+  init_noise_std: 1.0
+num_steps_per_env: 24
+save_interval: 50
+empirical_normalization: false
+max_iterations: 1000000

--- a/config/examples/chrono_gymnasium_ppo_current.yaml
+++ b/config/examples/chrono_gymnasium_ppo_current.yaml
@@ -1,0 +1,36 @@
+# Chrono-style PPO — current rsl-rl main schema (MLPModel + obs_groups)
+#
+# For rsl-rl-lib main / 5.x. Requires a VecEnv that returns TensorDict
+# observations with a "policy" group — see docs/guide/configuration.rst.
+# Users on rsl-rl-lib 2.3.x should use chrono_gymnasium_ppo_2x.yaml instead.
+
+num_steps_per_env: 24
+save_interval: 50
+obs_groups:
+  actor: ["policy"]
+  critic: ["policy"]
+algorithm:
+  class_name: PPO
+  learning_rate: 0.001
+  num_learning_epochs: 5
+  num_mini_batches: 4
+  schedule: adaptive
+  value_loss_coef: 1.0
+  clip_param: 0.2
+  use_clipped_value_loss: true
+  desired_kl: 0.01
+  entropy_coef: 0.005
+  gamma: 0.99
+  lam: 0.95
+  max_grad_norm: 1.0
+actor:
+  class_name: MLPModel
+  hidden_dims: [512, 256, 128]
+  activation: elu
+  distribution_cfg:
+    class_name: GaussianDistribution
+    init_std: 1.0
+critic:
+  class_name: MLPModel
+  hidden_dims: [512, 256, 128]
+  activation: elu


### PR DESCRIPTION

Documentation-only change for users of **[gym-chrono](https://github.com/projectchrono/gym-chrono)**, **[Chrono::Ray](https://github.com/uwsbel/chrono-ray)**, and other **Gymnasium + Project Chrono** stacks.

Many Chrono reproducers still pin **`rsl-rl-lib` 2.3.x** and pass a flat training dict with `policy.class_name: ActorCritic`. The current **main** branch uses a different layout (`actor` / `critic` `MLPModel` blocks and required `obs_groups`). This PR documents both families and ships example YAML for each.

### Changes

**README**

- Add a **version matrix** (`rsl-rl-lib` minor → YAML schema).
- Add a short **PyTorch on AMD ROCm** note (ROCm wheel install; `device="cuda"` on `OnPolicyRunner`; default PPO path uses generic `torch` ops).
- Link to gym-chrono and chrono-ray for full stack pins and Ray bootstrap.

**New example configs**

| File | For |
|------|-----|
| `config/examples/chrono_gymnasium_ppo_2x.yaml` | **rsl-rl-lib 2.3.x** — `ActorCritic` MLP `[512, 256, 128]`, ELU, standard PPO hyperparameters used in Chrono-Gymnasium-style locomotion reproducers. |
| `config/examples/chrono_gymnasium_ppo_current.yaml` | **main / 5.x** — `MLPModel` + `obs_groups` (see `docs/guide/configuration.rst`; requires `TensorDict` observations). |

**Optional**

-  `docs/guide/configuration.rst` pointing to the Chrono examples.

### Example usage

```python
import yaml
from rsl_rl.runners import OnPolicyRunner

with open("config/examples/chrono_gymnasium_ppo_2x.yaml") as f:
    train_cfg = yaml.safe_load(f)

runner = OnPolicyRunner(env, train_cfg, log_dir="logs", device="cuda")
```

### ROCm PyTorch (README excerpt)

```bash
pip install rsl-rl-lib==2.3.3
pip install --force-reinstall torch torchvision \
    --index-url https://download.pytorch.org/whl/rocm6.2
```

Pick a ROCm index that matches your driver. Re-pin ROCm `torch` after installing RSL-RL if pip resolves a CUDA build.

### Test plan

- [ ] `pip install rsl-rl-lib==2.3.3 pyyaml`
- [ ] `python3 -c "from rsl_rl.runners import OnPolicyRunner; print('import ok')"`
- [ ] Load `config/examples/chrono_gymnasium_ppo_2x.yaml` and assert `policy.class_name == "ActorCritic"` and `algorithm.class_name == "PPO"`
- [ ] (Optional, ROCm host) `python3 -c "import torch; print(torch.cuda.is_available())"` after ROCm wheel install
- [ ] README renders correctly on GitHub

```bash
pip install rsl-rl-lib==2.3.3 pyyaml
python3 -c "from rsl_rl.runners import OnPolicyRunner; print('import ok')"
python3 - <<'PY'
import yaml
from pathlib import Path
cfg = yaml.safe_load(Path("config/examples/chrono_gymnasium_ppo_2x.yaml").read_text())
assert cfg["policy"]["class_name"] == "ActorCritic"
assert cfg["algorithm"]["class_name"] == "PPO"
print("2.x yaml ok")
PY
```
