### PR TITLE
Synchronize normalization statistics across GPUs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,5 +41,6 @@ Please keep the lists sorted alphabetically.
 * Özhan Özen
 * Pascal Roth
 * Shaoshu Su
+* Zeng Qingcheng
 * Zhang Chong
 * Ziqi Fan

--- a/rsl_rl/modules/normalization.py
+++ b/rsl_rl/modules/normalization.py
@@ -60,16 +60,15 @@ class EmpiricalNormalization(nn.Module):
         mean_x = torch.mean(x, dim=0, keepdim=True)
 
         if torch.distributed.is_initialized():
-            # Compute the global mean first, then combine the local variances around that mean. Summing local variances
-            # alone would omit the variation between ranks with different means.
-            local_mean = mean_x
+            # Compute the global mean first, then combine the local variances around that mean
+            local_mean_x = mean_x
             torch.distributed.all_reduce(count_x)
-            mean_x = local_mean * x.shape[0]
-            torch.distributed.all_reduce(mean_x)
-            mean_x /= count_x
-            var_x = x.shape[0] * (var_x + (local_mean - mean_x).square())
-            torch.distributed.all_reduce(var_x)
-            var_x /= count_x
+            mean_sum_x = mean_x * x.shape[0]
+            torch.distributed.all_reduce(mean_sum_x)
+            mean_x = mean_sum_x / count_x
+            var_sum_x = x.shape[0] * (var_x + (local_mean_x - mean_x).square())
+            torch.distributed.all_reduce(var_sum_x)
+            var_x = var_sum_x / count_x
 
         self.count += count_x
         rate = count_x / self.count

--- a/rsl_rl/modules/normalization.py
+++ b/rsl_rl/modules/normalization.py
@@ -55,11 +55,24 @@ class EmpiricalNormalization(nn.Module):
         if self.until is not None and self.count >= self.until:
             return
 
-        count_x = x.shape[0]
-        self.count += count_x
-        rate = count_x / self.count
+        count_x = torch.tensor(x.shape[0], dtype=self.count.dtype, device=self.count.device)
         var_x = torch.var(x, dim=0, unbiased=False, keepdim=True)
         mean_x = torch.mean(x, dim=0, keepdim=True)
+
+        if torch.distributed.is_initialized():
+            # Compute the global mean first, then combine the local variances around that mean. Summing local variances
+            # alone would omit the variation between ranks with different means.
+            local_mean = mean_x
+            torch.distributed.all_reduce(count_x)
+            mean_x = local_mean * x.shape[0]
+            torch.distributed.all_reduce(mean_x)
+            mean_x /= count_x
+            var_x = x.shape[0] * (var_x + (local_mean - mean_x).square())
+            torch.distributed.all_reduce(var_x)
+            var_x /= count_x
+
+        self.count += count_x
+        rate = count_x / self.count
         delta_mean = mean_x - self._mean
         self._mean += rate * delta_mean
         self._var += rate * (var_x - self._var + delta_mean * (mean_x - self._mean))

--- a/rsl_rl/modules/normalization.py
+++ b/rsl_rl/modules/normalization.py
@@ -55,7 +55,7 @@ class EmpiricalNormalization(nn.Module):
         if self.until is not None and self.count >= self.until:
             return
 
-        count_x = torch.tensor(x.shape[0], dtype=self.count.dtype, device=self.count.device)
+        count_x = torch.tensor(x.shape[0], dtype=self.count.dtype, device=self.count.device)  # type: ignore
         var_x = torch.var(x, dim=0, unbiased=False, keepdim=True)
         mean_x = torch.mean(x, dim=0, keepdim=True)
 

--- a/tests/modules/test_normalization.py
+++ b/tests/modules/test_normalization.py
@@ -7,6 +7,8 @@
 
 import torch
 
+import pytest
+
 from rsl_rl.modules.normalization import EmpiricalDiscountedVariationNormalization, EmpiricalNormalization
 
 
@@ -93,6 +95,37 @@ class TestEmpiricalNormalization:
 
         assert not torch.any(torch.isnan(norm._mean))
         assert not torch.any(torch.isnan(norm._std))
+
+    def test_distributed_update_combines_mean_and_variance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Distributed updates should match moments computed from samples on all ranks."""
+        norm = EmpiricalNormalization(shape=1)
+        local_data = torch.tensor([[0.0], [2.0]])
+        remote_data = torch.tensor([[10.0], [14.0], [18.0]])
+        expected = torch.cat((local_data, remote_data))
+        call_count = 0
+
+        def fake_all_reduce(value: torch.Tensor) -> None:
+            nonlocal call_count
+            if call_count == 0:
+                value += remote_data.shape[0]
+            elif call_count == 1:
+                value += remote_data.sum(dim=0, keepdim=True)
+            else:
+                global_mean = expected.mean(dim=0, keepdim=True)
+                remote_var = remote_data.var(dim=0, unbiased=False, keepdim=True)
+                remote_mean = remote_data.mean(dim=0, keepdim=True)
+                value += remote_data.shape[0] * (remote_var + (remote_mean - global_mean).square())
+            call_count += 1
+
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+        monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+        norm.update(local_data)
+
+        assert call_count == 3
+        assert norm.count == expected.shape[0]
+        assert torch.allclose(norm.mean, expected.mean(dim=0))
+        assert torch.allclose(norm.std, expected.std(dim=0, unbiased=False))
 
 
 class TestEmpiricalDiscountedVariationNormalization:


### PR DESCRIPTION
## Summary

- synchronize `EmpiricalNormalization` batch statistics across distributed ranks
- combine rank-local variances with the between-rank mean correction instead of summing variances
- weight global moments by each rank's sample count, including uneven local batch sizes

## Problem

Each rank currently updates its running normalization statistics from local observations only. Although model gradients are synchronized, rank-local normalizers can therefore diverge and feed differently normalized inputs into otherwise synchronized models.

Local variances cannot be summed directly: that omits the variance caused by different local means. The global batch variance must include both within-rank variance and between-rank mean offsets.

## Implementation

- all-reduce the global sample count
- compute the sample-count-weighted global mean
- combine second central moments using `local_count * (local_var + (local_mean - global_mean)^2)`
- feed the resulting global batch count, mean, and variance into the existing running-moment update
- preserve the single-process path when no process group is initialized
- add the contributor entry required by `CONTRIBUTING.md`

## Tests

- `pytest tests/modules/test_normalization.py -q` — 9 passed
- `pre-commit run --all-files` — all hooks passed
- `pytest tests/ -q` — 165 passed, 11 failed on Windows because existing ONNX export and checkpoint tests reopen active `NamedTemporaryFile` paths; all failures are file sharing/permission errors unrelated to this change

The new regression test simulates another rank with a different sample count, mean, and variance, then checks that the synchronized running mean and standard deviation exactly match direct computation over the concatenated samples.
