### PR TITLE
Fix custom logger config mutation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,5 +41,6 @@ Please keep the lists sorted alphabetically.
 * Özhan Özen
 * Pascal Roth
 * Shaoshu Su
+* tandede
 * Zhang Chong
 * Ziqi Fan

--- a/rsl_rl/utils/logger.py
+++ b/rsl_rl/utils/logger.py
@@ -77,7 +77,11 @@ class Logger:
         """
         if self.log_dir is not None and not self.disable_logs:
             logger_cfg = self.cfg.get("logger", "tensorboard")
-            self.logger_type = logger_cfg if isinstance(logger_cfg, str) else logger_cfg.pop("class_name")
+            if isinstance(logger_cfg, str):
+                self.logger_type = logger_cfg
+            else:
+                logger_cfg = logger_cfg.copy()
+                self.logger_type = logger_cfg.pop("class_name")
 
             # Handle deprecated plain string logger types for W&B and Neptune
             if self.logger_type == "wandb" and isinstance(logger_cfg, str):

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021-2026, ETH Zurich and NVIDIA CORPORATION
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the training logger."""
+
+from __future__ import annotations
+
+import copy
+import pathlib
+
+import pytest
+
+import rsl_rl.utils.logger as logger_module
+from rsl_rl.utils.log_writer import LogWriter
+from rsl_rl.utils.logger import Logger
+
+
+class RecordingLogWriter(LogWriter):
+    """Minimal custom writer that records its constructor and config inputs."""
+
+    def __init__(self, log_dir: str, project_name: str) -> None:
+        """Initialize the writer with the forwarded custom logger arguments."""
+        self.log_dir = log_dir
+        self.project_name = project_name
+        self.train_cfg: dict | None = None
+
+    def add_scalar(self, tag: str, scalar_value: float, global_step: int) -> None:
+        """Implement the required scalar logging interface."""
+
+    def store_config(self, env_cfg: dict | object, train_cfg: dict) -> None:
+        """Record an independent snapshot of the uploaded training config."""
+        self.train_cfg = copy.deepcopy(train_cfg)
+
+
+def test_custom_log_writer_does_not_mutate_training_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """Custom writer construction should preserve the caller-owned config."""
+    train_cfg = {
+        "algorithm": {"rnd_cfg": None},
+        "logger": {"class_name": "RecordingLogWriter", "project_name": "config-regression"},
+    }
+    expected_cfg = copy.deepcopy(train_cfg)
+    monkeypatch.setattr(logger_module, "resolve_callable", lambda _: RecordingLogWriter)
+    monkeypatch.setattr(Logger, "_store_code_state", lambda _: [])
+
+    logger = Logger(
+        log_dir=str(tmp_path),
+        cfg=train_cfg,
+        env_cfg={},
+        num_envs=1,
+        is_distributed=False,
+        gpu_world_size=1,
+        gpu_global_rank=0,
+        device="cpu",
+    )
+    logger.init_logging_writer()
+
+    assert train_cfg == expected_cfg
+    assert isinstance(logger.writer, RecordingLogWriter)
+    assert logger.writer.log_dir == str(tmp_path)
+    assert logger.writer.project_name == "config-regression"
+    assert logger.writer.train_cfg == expected_cfg


### PR DESCRIPTION
## Summary

Preserve the caller-owned custom logger configuration while constructing a `LogWriter`.

`Logger.init_logging_writer()` currently removes `class_name` directly from `cfg["logger"]`. Because the same training configuration is uploaded immediately afterward, the stored configuration no longer identifies the logger implementation that was actually used. The mutation also remains visible to the caller after initialization.

## Reasoning

An earlier attempt in #85 kept `class_name` in the configuration but also forwarded it to algorithm and policy constructors as an unused argument. The review correctly rejected that approach because it weakened constructor contracts and introduced unnecessary parameters.

The custom logger path added later in #211 allows a narrower solution. Only the nested logger dictionary needs to be copied. `class_name` can then be removed from that local copy before forwarding the remaining keyword arguments, while the original training configuration remains intact.

## Implementation

- Keep plain string logger aliases unchanged.
- Shallow-copy dictionary-based logger configuration.
- Resolve and remove `class_name` only from the local copy.
- Add a strict custom `LogWriter` regression whose constructor accepts only the documented logger arguments.
- Verify that the caller-owned configuration and the configuration passed to `store_config()` both retain `class_name`.
- Add `tandede` to the contributor list as required by the contribution guide.

## Regression coverage

On the unmodified `main` branch, the regression fails because:

```text
{"logger": {"project_name": "config-regression"}}
```

no longer matches the original configuration containing:

```text
{"logger": {"class_name": "RecordingLogWriter", "project_name": "config-regression"}}
```

The patched implementation preserves the complete configuration while still excluding `class_name` from the writer constructor arguments.

## Validation

- `python -m pytest tests/ -q --tb=short` — 176 passed
- `pre-commit run --files CONTRIBUTORS.md rsl_rl/utils/logger.py tests/utils/test_logger.py` — passed
- `pre-commit run --all-files` — passed
- `git diff --check` — passed
