### PR TITLE
start_method=thread cause error with latest wandb

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Please keep the lists sorted alphabetically.
 * Emilio Palma
 * Eric Vollenweider
 * Fabian Jenelten
+* Kohei Sendai
 * Lorenzo Terenzi
 * Marko Bjelonic
 * Markus Portugall

--- a/rsl_rl/utils/wandb_log_writer.py
+++ b/rsl_rl/utils/wandb_log_writer.py
@@ -42,7 +42,6 @@ class WandbLogWriter(SummaryWriter, LogWriter):
             entity=entity,
             name=run_name,
             config={"log_dir": log_dir},
-            settings=wandb.Settings(start_method="thread"),
         )
 
         # Initialize set to keep track of logged videos


### PR DESCRIPTION
Title: Remove start_method from wandb.Settings

wandb 0.29.0 removed the deprecated start_method setting. Since wandb.Settings is a strict pydantic model, passing it now raises at wandb.init:

pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
start_method
  Extra inputs are not permitted [type=extra_forbidden, ...]

This makes --logger wandb crash on startup with wandb >= 0.29.0.

The setting has been non-functional since wandb 0.19.x, so removing it is safe for older wandb versions as well.