### PR TITLE
Avoid broadcast_object_list when broadcasting parameters

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ Please keep the lists sorted alphabetically.
 * Emilio Palma
 * Eric Vollenweider
 * Fabian Jenelten
+* Jichuan Hu
 * Kohei Sendai
 * Lorenzo Terenzi
 * Marko Bjelonic

--- a/rsl_rl/algorithms/distillation.py
+++ b/rsl_rl/algorithms/distillation.py
@@ -295,13 +295,9 @@ class Distillation:
 
     def broadcast_parameters(self) -> None:
         """Broadcast model parameters to all GPUs."""
-        # Obtain the model parameters on current GPU
-        model_params = [self._raw_student.state_dict(), self._raw_teacher.state_dict()]
-        # Broadcast the model parameters
-        torch.distributed.broadcast_object_list(model_params, src=0)
-        # Load the model parameters on all GPUs from source GPU
-        self._raw_student.load_state_dict(model_params[0])
-        self._raw_teacher.load_state_dict(model_params[1])
+        for model in (self._raw_student, self._raw_teacher):
+            for tensor in model.state_dict().values():
+                torch.distributed.broadcast(tensor, src=0)
 
     def reduce_parameters(self) -> None:
         """Collect gradients from all GPUs and average them.

--- a/rsl_rl/algorithms/ppo.py
+++ b/rsl_rl/algorithms/ppo.py
@@ -456,17 +456,12 @@ class PPO:
 
     def broadcast_parameters(self) -> None:
         """Broadcast model parameters to all GPUs."""
-        # Obtain the model parameters on current GPU
-        model_params = [self._raw_actor.state_dict(), self._raw_critic.state_dict()]
+        models = [self._raw_actor, self._raw_critic]
         if self.rnd:
-            model_params.append(self.rnd.predictor.state_dict())
-        # Broadcast the model parameters
-        torch.distributed.broadcast_object_list(model_params, src=0)
-        # Load the model parameters on all GPUs from source GPU
-        self._raw_actor.load_state_dict(model_params[0])
-        self._raw_critic.load_state_dict(model_params[1])
-        if self.rnd:
-            self.rnd.predictor.load_state_dict(model_params[2])
+            models += [self.rnd.predictor, self.rnd.target]
+        for model in models:
+            for tensor in model.state_dict().values():
+                torch.distributed.broadcast(tensor, src=0)
 
     def reduce_parameters(self) -> None:
         """Collect gradients from all GPUs and average them.


### PR DESCRIPTION
Fixes #231.

`broadcast_parameters` passed CUDA `state_dict`s to `torch.distributed.broadcast_object_list`,
which pickles its payload. Unpickling binds the tensors to the source device, so every rank ended
up holding a CUDA context on every visible GPU for the rest of the run — reported as ~425 MiB per
foreign GPU per rank, enough to OOM on smaller cards. This replaces it with a per-tensor
`torch.distributed.broadcast`, which hands the tensors to NCCL for a device-to-device copy with
nothing to unpickle.

Two things worth knowing:

- **The `load_state_dict` calls are gone on purpose.** `state_dict()` returns `param.detach()`,
  which shares storage with the model, so broadcasting those tensors writes the parameters in
  place. If that ever stops holding, the loop silently no-ops on the non-source ranks.
- **The tensors can't be flattened into one buffer** the way `reduce_parameters` does, because
  their dtypes differ — the normalizers register `count` as `torch.long` next to the float
  statistics.

Also broadcasts `rnd.target`, which was never synchronized. It is randomly initialized and frozen,
so each rank was scoring intrinsic reward against a different function.